### PR TITLE
Fix delete command format

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_INDEX;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,8 +23,8 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list.\n"
-            + "Parameters: " + PREFIX_DELETE_INDEX + "INDEX (must be a positive integer)...\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_DELETE_INDEX + "1";
+            + "Parameters: INDEX (must be a positive integer)...\n"
+            + "Example: " + COMMAND_WORD + "1,2";
 
     public static final String MESSAGE_DELETE_STUDENT_SUCCESS = "Deleted Student(s):\n%1$s";
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,7 +9,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_DELETE_INDEX = new Prefix("i/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,13 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_INDEX;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -28,18 +27,17 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DELETE_INDEX);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
 
-        if (!DeleteCommandParser.arePrefixesPresent(argMultimap, PREFIX_DELETE_INDEX)
-                || !argMultimap.getPreamble().isEmpty()) {
+        List<String> indicesList = List.of(argMultimap.getPreamble().split(","));
+
+        if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
         try {
-
             Set<Index> indices;
-            Optional<Set<Index>> optionalIndices = parseIndicesForDelete(argMultimap.getAllValues(PREFIX_DELETE_INDEX));
+            Optional<Set<Index>> optionalIndices = parseIndicesForDelete(indicesList);
             if (optionalIndices.isPresent() && !optionalIndices.get().isEmpty()) {
                 indices = optionalIndices.get();
                 return new DeleteCommand(indices);
@@ -66,14 +64,6 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
         Collection<String> indicesSet = indices.size() == 1 && indices.contains("") ? Collections.emptySet() : indices;
         return Optional.of(ParserUtil.parseIndices(indicesSet));
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalStudents.AMY;
 
@@ -62,7 +61,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete " + PREFIX_DELETE_INDEX + "9";
+        String deleteCommand = "delete 9";
         assertCommandException(deleteCommand, String.format(MESSAGE_INVALID_INDEX_SHOWN, "9"));
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
@@ -54,7 +53,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + PREFIX_DELETE_INDEX + INDEX_FIRST_STUDENT.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_STUDENT.getOneBased());
         Set<Index> firstIndexSet = new HashSet<>();
         firstIndexSet.add(INDEX_FIRST_STUDENT);
         assertEquals(new DeleteCommand(firstIndexSet), command);

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -30,7 +29,7 @@ public class DeleteCommandParserTest {
     public void parse_singleDeleteValidArgs_returnsDeleteCommand() {
         Set<Index> firstIndexSet = new HashSet<>();
         firstIndexSet.add(INDEX_FIRST_STUDENT);
-        assertParseSuccess(parser, " " + PREFIX_DELETE_INDEX + "1", new DeleteCommand(firstIndexSet));
+        assertParseSuccess(parser, "1", new DeleteCommand(firstIndexSet));
     }
 
     @Test
@@ -38,7 +37,7 @@ public class DeleteCommandParserTest {
         Set<Index> indexSet = new HashSet<>();
         indexSet.add(INDEX_FIRST_STUDENT);
         indexSet.add(INDEX_SECOND_STUDENT);
-        assertParseSuccess(parser, " " + PREFIX_DELETE_INDEX + "1 " + PREFIX_DELETE_INDEX + "2 ",
+        assertParseSuccess(parser, "1 ,2 ",
                 new DeleteCommand(indexSet));
     }
 
@@ -47,16 +46,22 @@ public class DeleteCommandParserTest {
         assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
+    @Test
+    public void parse_someValidSomeInvalidArgsNoTag_throwsParseException() {
+        assertParseFailure(parser, "1, a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
 
     @Test
     public void parse_invalidArgsNoNum_throwsParseException() {
-        assertParseFailure(parser, PREFIX_DELETE_INDEX.toString(),
+        assertParseFailure(parser, ",",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgsSomeNoNum_throwsParseException() {
-        assertParseFailure(parser, PREFIX_DELETE_INDEX + " 1" + PREFIX_DELETE_INDEX,
+        assertParseFailure(parser, ", 1,",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -42,16 +42,22 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_noArgs_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_invalidArgsNoTag_throwsParseException() {
         assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
+
     @Test
     public void parse_someValidSomeInvalidArgsNoTag_throwsParseException() {
         assertParseFailure(parser, "1, a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
-
 
     @Test
     public void parse_invalidArgsNoNum_throwsParseException() {


### PR DESCRIPTION
Closes #75.

The current format for the delete command is `delete i/<index>`, which differs from the specification.

Let's change it to `delete <index>` to maintain consistency.