### PR TITLE
Make FindCommand return intersection of multiple arguments

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,11 +2,13 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -25,8 +27,11 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        List<String> nameKeywords = List.of(trimmedArgs.split("\\s+"));
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        List<? extends Predicate<Student>> predicateList =
+                nameKeywords.stream().map(name -> new NameContainsKeywordsPredicate(List.of(name))).toList();
+
+        return new FindCommand(predicateList);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,13 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalStudents.CARL;
-import static seedu.address.testutil.TypicalStudents.ELLE;
-import static seedu.address.testutil.TypicalStudents.FIONA;
+import static seedu.address.testutil.TypicalStudents.BENSON;
+import static seedu.address.testutil.TypicalStudents.DANIEL;
 import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -65,20 +67,36 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multipleStudentsFound() {
-        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredStudentList(predicate);
+    public void execute_oneKeyword_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 2);
+        FindCommand command = new FindCommand(List.of(
+                new NameContainsKeywordsPredicate(List.of("Meier"))
+        ));
+        expectedModel.updateFilteredStudentList(command.getPredicate());
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredStudentList());
+        assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_oneStudentFound() {
+        String expectedMessage = String.format(MESSAGE_STUDENTS_LISTED_OVERVIEW, 1);
+        FindCommand command = new FindCommand(List.of(
+                new NameContainsKeywordsPredicate(List.of("Meier")),
+                new NameContainsKeywordsPredicate(List.of("Benson"))
+        ));
+        expectedModel.updateFilteredStudentList(command.getPredicate());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredStudentList());
     }
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(predicate);
-        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        List<Predicate<Student>> predicates = List.of(
+                new NameContainsKeywordsPredicate(List.of("Alice")),
+                new NameContainsKeywordsPredicate(List.of("Bob"))
+        );
+        FindCommand findCommand = new FindCommand(predicates);
+        String expected = FindCommand.class.getCanonicalName() + "{predicates=" + predicates + "}";
         assertEquals(expected, findCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -79,7 +79,12 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        FindCommand expectedCommand = new FindCommand(List.of(
+            new NameContainsKeywordsPredicate(List.of("foo")),
+                new NameContainsKeywordsPredicate(List.of("bar")),
+                new NameContainsKeywordsPredicate(List.of("baz"))
+        ));
+        assertEquals(expectedCommand, command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,12 +4,14 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
+import seedu.address.model.student.Student;
 
 public class FindCommandParserTest {
 
@@ -21,10 +23,26 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_validSingleArg_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(
+                new NameContainsKeywordsPredicate(List.of("Alice"))
+        );
+
+        // no leading and trailing whitespaces
+        assertParseSuccess(parser, "Alice", expectedFindCommand);
+
+        // multiple whitespaces around keyword
+        assertParseSuccess(parser, " \n Alice \n  \t", expectedFindCommand);
+    }
+
+    @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        List<Predicate<Student>> predicates = List.of(
+                new NameContainsKeywordsPredicate(List.of("Alice")),
+                new NameContainsKeywordsPredicate(List.of("Bob"))
+        );
+        FindCommand expectedFindCommand = new FindCommand(predicates);
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords


### PR DESCRIPTION
Closes #60.

Currently, `find alice ben` returns all students whose names contain either "alice" or "ben", case-insensitive.

Let's,
- Make `find alice ben` return all students whose names contain "alice" *and* "ben", case-insensitive.
- Make FindCommand able to accept a list of predicates to apply, thus effectively giving the intersection.

This is because it will be more intuitive later on for `find n/alice c/cs2030s` to find the students called "alice" who are also taking "CS2030S", rather than finding all students who are either called "alice" or are taking "CS2030S".

The ability to specify union (#63) will be added in a later PR. 