### PR TITLE
Add semicolon as default prefix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,17 +131,17 @@ Examples:
 
 Deletes the specified student from the address book.
 
-Format: `delete i/INDEX...`
+Format: `delete INDEX[;INDEX]...`
 
 * Deletes the student at the specified `INDEX`.
 * The index refers to the index number shown in the displayed student list.
 * The index **must be a positive integer** 1, 2, 3, …​
-* Can delete multiple items at once
+* Can delete multiple items at once by separating indices with semicolons (;)
 
 Examples:
-* `list` followed by `delete i/2` deletes the 2nd student in the address book.
-* `list` followed by `delete i/2 i/3` deletes the 2nd and 3rd student in the address book.
-* `find Betsy` followed by `delete i/1` deletes the 1st student in the results of the `find` command.
+* `list` followed by `delete 2` deletes the 2nd student in the address book.
+* `list` followed by `delete 2;3` deletes the 2nd and 3rd student in the address book.
+* `find Betsy` followed by `delete 1` deletes the 1st student in the results of the `find` command.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DEFAULT;
+import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list.\n"
             + "Parameters: INDEX (must be a positive integer)...\n"
-            + "Example: " + COMMAND_WORD + " 1" + PREFIX_DEFAULT + "2";
+            + "Example: " + COMMAND_WORD + " 1" + DEFAULT_DELIMITER + "2";
 
     public static final String MESSAGE_DELETE_STUDENT_SUCCESS = "Deleted Student(s):\n%1$s";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEFAULT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +25,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list.\n"
             + "Parameters: INDEX (must be a positive integer)...\n"
-            + "Example: " + COMMAND_WORD + "1,2";
+            + "Example: " + COMMAND_WORD + " 1" + PREFIX_DEFAULT + "2";
 
     public static final String MESSAGE_DELETE_STUDENT_SUCCESS = "Deleted Student(s):\n%1$s";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -44,7 +44,7 @@ public class EditCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com "
-            + PREFIX_COURSE + "CS2103T,CS2101";
+            + PREFIX_COURSE + "CS2103T;CS2101";
 
     public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited Student: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -67,8 +68,8 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         // For each course string (this could be a CSV or a single course)
         for (String courseString : courses) {
-            // Split by commas to support CSV input within a single `c/` prefix
-            String[] splitCourses = courseString.split(",");
+
+            List<String> splitCourses = ArgumentTokenizer.tokenizeWithDefault(courseString);
             // Add each course after trimming whitespace
             for (String course : splitCourses) {
                 parsedCourses.add(course.trim());

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -51,7 +51,11 @@ public class ArgumentTokenizer {
         while (prefixPosition != -1) {
             PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
             positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            if (prefix.getPrefix().equals(";")) {
+                prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition + 1);
+            } else {
+                prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            }
         }
 
         return positions;
@@ -70,9 +74,13 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
-        return prefixIndex == -1 ? -1
-                : prefixIndex + 1; // +1 as offset for whitespace
+        if (!prefix.equals(";")) {
+            int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+            return prefixIndex == -1 ? -1
+                    : prefixIndex + 1; // +1 as offset for whitespace
+        } else {
+            return argsString.indexOf(prefix, fromIndex);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +31,25 @@ public class ArgumentTokenizer {
     }
 
     /**
+     * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps the default delimter to
+     * its argument values. Only the default delimiter will be recognized in the arguments string.
+     *
+     * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @return List that splits the argument using the default delimiter
+     */
+    public static List<String> tokenizeWithDefault(String argsString) {
+        List<PrefixPosition> positions = findAllPrefixPositions(argsString, DEFAULT_DELIMITER);
+        ArgumentMultimap map = extractArguments(argsString, positions);
+        List<String> items = map.getAllValues(DEFAULT_DELIMITER);
+        if (map.getPreamble().isEmpty()) {
+            return items;
+        }
+        items.add(map.getPreamble());
+        return items;
+
+    }
+
+    /**
      * Finds all zero-based prefix positions in the given arguments string.
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
@@ -51,7 +72,7 @@ public class ArgumentTokenizer {
         while (prefixPosition != -1) {
             PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
             positions.add(extendedPrefix);
-            if (prefix.getPrefix().equals(";")) {
+            if (prefix.equals(DEFAULT_DELIMITER)) {
                 prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition + 1);
             } else {
                 prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
@@ -74,7 +95,7 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        if (!prefix.equals(";")) {
+        if (!prefix.equals(DEFAULT_DELIMITER.getPrefix())) {
             int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
             return prefixIndex == -1 ? -1
                     : prefixIndex + 1; // +1 as offset for whitespace

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,5 +10,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
+    public static final Prefix PREFIX_DEFAULT = new Prefix(";");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
-    public static final Prefix PREFIX_DEFAULT = new Prefix(";");
+    public static final Prefix DEFAULT_DELIMITER = new Prefix(";");
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DEFAULT;
+import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -28,13 +28,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DEFAULT);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, DEFAULT_DELIMITER);
 
         if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
-        List<String> indicesListWithoutFirst = argMultimap.getAllValues(PREFIX_DEFAULT);
+        List<String> indicesListWithoutFirst = argMultimap.getAllValues(DEFAULT_DELIMITER);
         String firstIndexString = argMultimap.getPreamble();
         List<String> indicesList = joinIndices(indicesListWithoutFirst, firstIndexString);
         assert !indicesList.isEmpty() : "List of indices here should at least have an item";

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEFAULT;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -27,24 +28,23 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
-
-        List<String> indicesList = List.of(argMultimap.getPreamble().split(","));
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DEFAULT);
 
         if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
+        List<String> indicesListWithoutFirst = argMultimap.getAllValues(PREFIX_DEFAULT);
+        String firstIndexString = argMultimap.getPreamble();
+        List<String> indicesList = joinIndices(indicesListWithoutFirst, firstIndexString);
+        assert !indicesList.isEmpty() : "List of indices here should at least have an item";
+
         try {
             Set<Index> indices;
             Optional<Set<Index>> optionalIndices = parseIndicesForDelete(indicesList);
-            if (optionalIndices.isPresent() && !optionalIndices.get().isEmpty()) {
-                indices = optionalIndices.get();
-                return new DeleteCommand(indices);
-            } else {
-                throw new ParseException(MESSAGE_EMPTY_INDEX);
-            }
-
+            assert optionalIndices.isPresent() : "Optional set of indices should not be empty or return null";
+            indices = optionalIndices.get();
+            return new DeleteCommand(indices);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
@@ -64,6 +64,18 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
         Collection<String> indicesSet = indices.size() == 1 && indices.contains("") ? Collections.emptySet() : indices;
         return Optional.of(ParserUtil.parseIndices(indicesSet));
+    }
+
+
+    /**
+     * Appends the preamble of the parse result to the list.
+     * @param indicesWithoutFirst collection of Strings representing indices, excluding the first index.
+     * @param first The String representation of the first index
+     * @return A List which contains String representation of the indices.
+     */
+    private List<String> joinIndices(List<String> indicesWithoutFirst, String first) {
+        indicesWithoutFirst.add(first);
+        return indicesWithoutFirst;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -28,16 +27,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, DEFAULT_DELIMITER);
 
-        if (argMultimap.getPreamble().isEmpty()) {
+        List<String> indicesList = ArgumentTokenizer.tokenizeWithDefault(args);
+        if (indicesList.isEmpty() || indicesList.stream().allMatch(String::isEmpty)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
-        List<String> indicesListWithoutFirst = argMultimap.getAllValues(DEFAULT_DELIMITER);
-        String firstIndexString = argMultimap.getPreamble();
-        List<String> indicesList = joinIndices(indicesListWithoutFirst, firstIndexString);
-        assert !indicesList.isEmpty() : "List of indices here should at least have an item";
 
         try {
             Set<Index> indices;

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -13,6 +13,7 @@ public class ArgumentTokenizerTest {
     private final Prefix pSlash = new Prefix("p/");
     private final Prefix dashT = new Prefix("-t");
     private final Prefix hatQ = new Prefix("^Q");
+    private final Prefix semicolon = new Prefix(";");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -124,6 +125,19 @@ public class ArgumentTokenizerTest {
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
         assertArgumentPresent(argMultimap, hatQ, "", "");
+    }
+
+    @Test
+    public void tokenize_multipleArgumentsWithSemicolons() {
+        // check if semicolon works as expected
+        // input parsed, regardless of space before or after semicolons
+        String argsString = "SomePreambleString -t dashT-Value ; words after semicolon trimmed -t" +
+                " another dashT value;no space before and after semicolon;";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, dashT, semicolon);
+        assertPreamblePresent(argMultimap, "SomePreambleString");
+        assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value");
+        assertArgumentPresent(argMultimap, semicolon, "words after semicolon trimmed",
+                "no space before and after semicolon", "");
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -131,8 +131,8 @@ public class ArgumentTokenizerTest {
     public void tokenize_multipleArgumentsWithSemicolons() {
         // check if semicolon works as expected
         // input parsed, regardless of space before or after semicolons
-        String argsString = "SomePreambleString -t dashT-Value ; words after semicolon trimmed -t" +
-                " another dashT value;no space before and after semicolon;";
+        String argsString = "SomePreambleString -t dashT-Value ; words after semicolon trimmed -t"
+                + " another dashT value;no space before and after semicolon;";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, dashT, semicolon);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value");

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -141,6 +141,14 @@ public class ArgumentTokenizerTest {
     }
 
     @Test
+    public void tokenize_onlyOneSemicolonWithSemicolons() {
+        String argsString = ";";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, semicolon);
+        assertPreamblePresent(argMultimap, "");
+        assertArgumentPresent(argMultimap, semicolon, "");
+    }
+
+    @Test
     public void tokenize_multipleArgumentsJoined() {
         String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEFAULT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -37,7 +38,7 @@ public class DeleteCommandParserTest {
         Set<Index> indexSet = new HashSet<>();
         indexSet.add(INDEX_FIRST_STUDENT);
         indexSet.add(INDEX_SECOND_STUDENT);
-        assertParseSuccess(parser, "1 ,2 ",
+        assertParseSuccess(parser, "1" + PREFIX_DEFAULT + " 2",
                 new DeleteCommand(indexSet));
     }
 
@@ -47,6 +48,8 @@ public class DeleteCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
+
+
     @Test
     public void parse_invalidArgsNoTag_throwsParseException() {
         assertParseFailure(parser, "a",
@@ -55,19 +58,19 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_someValidSomeInvalidArgsNoTag_throwsParseException() {
-        assertParseFailure(parser, "1, a",
+        assertParseFailure(parser, "1" + PREFIX_DEFAULT + " a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgsNoNum_throwsParseException() {
-        assertParseFailure(parser, ",",
+        assertParseFailure(parser, PREFIX_DEFAULT.toString(),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgsSomeNoNum_throwsParseException() {
-        assertParseFailure(parser, ", 1,",
+        assertParseFailure(parser, PREFIX_DEFAULT + " 1" + PREFIX_DEFAULT,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DEFAULT;
+import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -38,7 +38,7 @@ public class DeleteCommandParserTest {
         Set<Index> indexSet = new HashSet<>();
         indexSet.add(INDEX_FIRST_STUDENT);
         indexSet.add(INDEX_SECOND_STUDENT);
-        assertParseSuccess(parser, "1" + PREFIX_DEFAULT + " 2",
+        assertParseSuccess(parser, "1" + DEFAULT_DELIMITER + " 2",
                 new DeleteCommand(indexSet));
     }
 
@@ -58,19 +58,19 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_someValidSomeInvalidArgsNoTag_throwsParseException() {
-        assertParseFailure(parser, "1" + PREFIX_DEFAULT + " a",
+        assertParseFailure(parser, "1" + DEFAULT_DELIMITER + " a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgsNoNum_throwsParseException() {
-        assertParseFailure(parser, PREFIX_DEFAULT.toString(),
+        assertParseFailure(parser, DEFAULT_DELIMITER.toString(),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArgsSomeNoNum_throwsParseException() {
-        assertParseFailure(parser, PREFIX_DEFAULT + " 1" + PREFIX_DEFAULT,
+        assertParseFailure(parser, DEFAULT_DELIMITER + " 1" + DEFAULT_DELIMITER,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Fixes #84 

- Added semicolon (";") as a global default prefix
- Made changes to ArgumentTokenizer to handle tokenizing specific to semicolon (meaning that handling tokenizing for semicolon is slightly different from all other prefixes)