### PR TITLE
Add test cases

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -41,9 +41,6 @@ public class ArgumentTokenizer {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, DEFAULT_DELIMITER);
         ArgumentMultimap map = extractArguments(argsString, positions);
         List<String> items = map.getAllValues(DEFAULT_DELIMITER);
-        if (map.getPreamble().isEmpty()) {
-            return items;
-        }
         items.add(map.getPreamble());
         return items;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -18,8 +18,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 
-    public static final String MESSAGE_EMPTY_INDEX = "Index is not provided.";
-
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
@@ -29,7 +27,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         requireNonNull(args);
 
         List<String> indicesList = ArgumentTokenizer.tokenizeWithDefault(args);
-        if (indicesList.isEmpty() || indicesList.stream().allMatch(String::isEmpty)) {
+        if (indicesList.isEmpty() || indicesList.stream().anyMatch(String::isEmpty)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
@@ -61,16 +59,5 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         return Optional.of(ParserUtil.parseIndices(indicesSet));
     }
 
-
-    /**
-     * Appends the preamble of the parse result to the list.
-     * @param indicesWithoutFirst collection of Strings representing indices, excluding the first index.
-     * @param first The String representation of the first index
-     * @return A List which contains String representation of the indices.
-     */
-    private List<String> joinIndices(List<String> indicesWithoutFirst, String first) {
-        indicesWithoutFirst.add(first);
-        return indicesWithoutFirst;
-    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -71,18 +71,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
-        Set<Index> outOfBoundIndexSet = new HashSet<>();
-        outOfBoundIndexSet.add(outOfBoundIndex);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexSet);
-
-        assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
-                String.valueOf(outOfBoundIndex.getOneBased())));
-    }
-
-    @Test
-    public void execute_multipleInvalidIndexUnfilteredList_throwsCommandException() {
+    public void execute_allInvalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredStudentList().size() + 2);
         Set<Index> outOfBoundIndexSet = new HashSet<>();
@@ -98,14 +87,29 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_oneInvalidIndexUnfilteredList_throwsCommandException() {
+    public void execute_someOfManyInvalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredStudentList().size() + 2);
+        Set<Index> outOfBoundIndexSet = new HashSet<>();
+        outOfBoundIndexSet.add(outOfBoundIndex);
+        outOfBoundIndexSet.add(outOfBoundIndex2);
+        outOfBoundIndexSet.add(INDEX_FIRST_STUDENT);
+        outOfBoundIndexSet.add(INDEX_SECOND_STUDENT);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexSet);
+
+        String formattedOutOfBoundIndices = outOfBoundIndex.getOneBased() + ", " + outOfBoundIndex2.getOneBased();
+
+        assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                formattedOutOfBoundIndices));
+    }
+
+    @Test
+    public void execute_oneOfOneInvalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         Set<Index> outOfBoundIndexSet = new HashSet<>();
         outOfBoundIndexSet.add(outOfBoundIndex);
         outOfBoundIndexSet.add(INDEX_FIRST_STUDENT);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndexSet);
-
-
 
         assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
                 String.valueOf(outOfBoundIndex.getOneBased())));

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -82,7 +82,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgsAllEmptyString_throwsParseException() {
-        assertParseFailure(parser, "" + DEFAULT_DELIMITER  + DEFAULT_DELIMITER,
+        assertParseFailure(parser, "" + DEFAULT_DELIMITER + DEFAULT_DELIMITER,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -51,26 +51,40 @@ public class DeleteCommandParserTest {
 
 
     @Test
-    public void parse_invalidArgsNoTag_throwsParseException() {
+    public void parse_invalidArgsNotNum_throwsParseException() {
         assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_someValidSomeInvalidArgsNoTag_throwsParseException() {
+    public void parse_someValidSomeInvalidArgsNotNum_throwsParseException() {
         assertParseFailure(parser, "1" + DEFAULT_DELIMITER + " a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_invalidArgsNoNum_throwsParseException() {
+    public void parse_invalidArgsOnlyDelimiter_throwsParseException() {
         assertParseFailure(parser, DEFAULT_DELIMITER.toString(),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_invalidArgsSomeNoNum_throwsParseException() {
-        assertParseFailure(parser, DEFAULT_DELIMITER + " 1" + DEFAULT_DELIMITER,
+    public void parse_invalidArgsEmptyString_throwsParseException() {
+        assertParseFailure(parser, "",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_invalidArgsOneEmptyString_throwsParseException() {
+        assertParseFailure(parser, "2 " + DEFAULT_DELIMITER + " 1" + DEFAULT_DELIMITER,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsAllEmptyString_throwsParseException() {
+        assertParseFailure(parser, "" + DEFAULT_DELIMITER  + DEFAULT_DELIMITER,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -48,8 +48,6 @@ public class DeleteCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
-
-
     @Test
     public void parse_invalidArgsNotNum_throwsParseException() {
         assertParseFailure(parser, "a",
@@ -86,5 +84,16 @@ public class DeleteCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
+    @Test
+    public void parse_invalidArgsSomeEmptyString_throwsParseException() {
+        assertParseFailure(parser, DEFAULT_DELIMITER + "3" + DEFAULT_DELIMITER,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsSpaces_throwsParseException() {
+        assertParseFailure(parser, " " + DEFAULT_DELIMITER + " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
 
 }


### PR DESCRIPTION
Fixes #82 

- Add test cases for DeleteCommand and DeleteCommandParser
- DeleteCommand now throws error if there is any empty strings returned by tokenizer