### PR TITLE
Fix edit command syntax

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -82,7 +82,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Collection<String> parsedCourses = new HashSet<>();
         for (String course : courses) {
-            String[] parsedCourse = course.split(",");
+            String[] parsedCourse = course.split(";");
             Arrays.stream(parsedCourse).forEach(parsedCourses::add);
         }
         Collection<String> courseSet = courses.size() == 1 && courses.contains("")


### PR DESCRIPTION
Changes edit delimiter from `,` to `;` for consistency.

