### PR TITLE
Change NameContainsKeywordsPredicate logic

### DIFF
--- a/src/main/java/seedu/address/model/student/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/NameContainsKeywordsPredicate.java
@@ -1,10 +1,8 @@
 package seedu.address.model.student;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**

--- a/src/main/java/seedu/address/model/student/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/student/NameContainsKeywordsPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.student;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -18,8 +19,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
+        String lowercaseName = student.getName().fullName.toLowerCase();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(student.getName().fullName, keyword));
+                .anyMatch(keyword -> lowercaseName.contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -25,7 +25,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validSingleNameArg_returnsFindCommand() throws ParseException {
+    public void parse_validSingleNameArg_returnsFindCommand() {
         FindCommand expectedFindCommand = new FindCommand(
                 new NameContainsKeywordsPredicate(List.of("Alice"))
         );
@@ -38,7 +38,20 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validSingleCourseArg_returnsFindCommand() throws ParseException {
+    public void parse_validSpacedNameArg_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(
+                new NameContainsKeywordsPredicate(List.of("Alice Tan"))
+        );
+
+        // no leading and trailing whitespaces
+        assertParseSuccess(parser, " n/Alice Tan", expectedFindCommand);
+
+        // multiple whitespaces around keyword
+        assertParseSuccess(parser, " \n n/Alice Tan\n  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validSingleCourseArg_returnsFindCommand() {
         FindCommand expectedFindCommand = new FindCommand(
                 new IsStudentOfCoursePredicate(List.of("CS2030S"))
         );

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,7 +10,6 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.student.IsStudentOfCoursePredicate;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;

--- a/src/test/java/seedu/address/model/student/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/student/NameContainsKeywordsPredicateTest.java
@@ -49,6 +49,10 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new StudentBuilder().withName("Alice Bob").build()));
 
+        // One big keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice Bob"));
+        assertTrue(predicate.test(new StudentBuilder().withName("Alice Bob").build()));
+
         // Only one matching keyword
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
         assertTrue(predicate.test(new StudentBuilder().withName("Alice Carol").build()));


### PR DESCRIPTION
Closes #101.

Previously, `NameContainsKeywordsPredicate` makes use of `StringUtil.containsWordIgnoreCase`, which only accepts a single word as an argument.

Let's,
- Change the logic to accept a string literal as is, e.g. `find n/alice tan` will successfully find a student containing the string sequence "alice tan", case-insensitive.