### PR TITLE
Add addconsult command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -54,7 +54,10 @@ public class Messages {
      */
     public static String format(Consultation consult) {
         final StringBuilder builder = new StringBuilder();
-        builder.append("TODO");
+        builder.append("Date: ")
+                .append(consult.getDate().toString())
+                .append("; Time: ")
+                .append(consult.getTime().toString());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 
 /**
@@ -45,6 +46,15 @@ public class Messages {
                 .append(student.getEmail())
                 .append("; Courses: ");
         student.getCourses().forEach(builder::append);
+        return builder.toString();
+    }
+
+    /**
+     * Formats the {@code consult} for display to the user.
+     */
+    public static String format(Consultation consult) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("TODO");
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/consult/AddConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consult/AddConsultCommand.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands.consult;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.consultation.Consultation;
+import seedu.address.model.Model;
+
+/**
+ * Adds a student to the address book.
+ */
+public class AddConsultCommand extends Command {
+
+    public static final String COMMAND_WORD = "addconsult";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a consultation to TAHub. "
+            + "Parameters: "
+            + PREFIX_DATE + "DATE "
+            + PREFIX_TIME + "TIME "
+            + "[" + PREFIX_NAME + "COURSE]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_DATE + "2024-10-20 "
+            + PREFIX_TIME + "14:00 "
+            + PREFIX_NAME + "John Doe";
+
+    public static final String MESSAGE_SUCCESS = "New consult added: %1$s";
+
+    private final Consultation newConsult;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Student}
+     */
+    public AddConsultCommand(Consultation newConsult) {
+        requireNonNull(newConsult);
+        this.newConsult = newConsult;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.addConsult(newConsult);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(newConsult)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddConsultCommand)) {
+            return false;
+        }
+
+        AddConsultCommand otherAddCommand = (AddConsultCommand) other;
+        return newConsult.equals(otherAddCommand.newConsult);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("newConsult", newConsult)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/consultation/AddConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/AddConsultCommand.java
@@ -1,8 +1,7 @@
-package seedu.address.logic.commands.consult;
+package seedu.address.logic.commands.consultation;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -10,8 +9,8 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.consultation.Consultation;
 import seedu.address.model.Model;
+import seedu.address.model.consultation.Consultation;
 
 /**
  * Adds a student to the address book.
@@ -24,11 +23,9 @@ public class AddConsultCommand extends Command {
             + "Parameters: "
             + PREFIX_DATE + "DATE "
             + PREFIX_TIME + "TIME "
-            + "[" + PREFIX_NAME + "COURSE]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DATE + "2024-10-20 "
-            + PREFIX_TIME + "14:00 "
-            + PREFIX_NAME + "John Doe";
+            + PREFIX_TIME + "14:00 ";
 
     public static final String MESSAGE_SUCCESS = "New consult added: %1$s";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,8 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.consultation.AddConsultCommand;
+import seedu.address.logic.parser.consultation.AddConsultCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -55,6 +57,9 @@ public class AddressBookParser {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+        case AddConsultCommand.COMMAND_WORD:
+            return new AddConsultCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -77,4 +77,14 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Returns true if the {@code ArgumentMultimap} contains all the given prefixes.
+     *
+     * @param prefixes Prefixes to test for.
+     * @return True if all prefixes are present.
+     */
+    public boolean arePrefixesPresent(Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,6 +10,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_TIME = new Prefix("t/");
     public static final Prefix DEFAULT_DELIMITER = new Prefix(";");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,11 +6,11 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
+    public static final Prefix PREFIX_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_TIME = new Prefix("t/");
     public static final Prefix DEFAULT_DELIMITER = new Prefix(";");
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.consultation.Date;
+import seedu.address.model.consultation.Time;
 import seedu.address.model.course.Course;
 import seedu.address.model.student.Email;
 import seedu.address.model.student.Name;
@@ -20,6 +22,21 @@ import seedu.address.model.student.Phone;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+
+    /**
+     * Parses a {@code String date} into a {@code Date}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code date} is invalid.
+     */
+    public static Date parseDate(String date) throws ParseException {
+        requireNonNull(date);
+        String trimmedDate = date.trim();
+        if (!Date.isValidDate(trimmedDate)) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        return new Date(trimmedDate);
+    }
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -116,5 +133,20 @@ public class ParserUtil {
             courseSet.add(parseCourse(courseName));
         }
         return courseSet;
+    }
+
+    /**
+     * Parses a {@code String time} into a {@code Time}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code time} is invalid.
+     */
+    public static Time parseTime(String time) throws ParseException {
+        requireNonNull(time);
+        String trimmedTime = time.trim();
+        if (!Time.isValidTime(trimmedTime)) {
+            throw new ParseException(Time.MESSAGE_CONSTRAINTS);
+        }
+        return new Time(trimmedTime);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/consultation/AddConsultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultation/AddConsultCommandParser.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.course.Course;
+import seedu.address.model.student.Email;
+import seedu.address.model.student.Name;
+import seedu.address.model.student.Phone;
+import seedu.address.model.student.Student;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddCommandParser implements Parser<AddCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
+            PREFIX_EMAIL, PREFIX_COURSE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
+            || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+
+        // Parse courses; if none are provided, use an empty set
+        Set<Course> courseList = parseCourses(argMultimap.getAllValues(PREFIX_COURSE)).orElse(new HashSet<>());
+
+        Student student = new Student(name, phone, email, courseList);
+
+        return new AddCommand(student);
+    }
+
+    /**
+     * Parses {@code Collection<String> courses} into a {@code Set<Course>} if {@code courses} is non-empty.
+     * This method supports both CSV input and multiple `c/` prefixes.
+     */
+    private Optional<Set<Course>> parseCourses(Collection<String> courses) throws ParseException {
+        assert courses != null;
+
+        if (courses.isEmpty()) {
+            return Optional.empty(); // If no courses are provided, return empty Optional
+        }
+
+        Set<String> parsedCourses = new HashSet<>();
+
+        // For each course string (this could be a CSV or a single course)
+        for (String courseString : courses) {
+
+            List<String> splitCourses = ArgumentTokenizer.tokenizeWithDefault(courseString);
+            // Add each course after trimming whitespace
+            for (String course : splitCourses) {
+                parsedCourses.add(course.trim());
+            }
+        }
+
+        return Optional.of(ParserUtil.parseCourses(parsedCourses));
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/consultation/AddConsultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultation/AddConsultCommandParser.java
@@ -1,89 +1,46 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.consultation;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
-import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.consultation.AddConsultCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.course.Course;
-import seedu.address.model.student.Email;
-import seedu.address.model.student.Name;
-import seedu.address.model.student.Phone;
-import seedu.address.model.student.Student;
+import seedu.address.model.consultation.Consultation;
+import seedu.address.model.consultation.Date;
+import seedu.address.model.consultation.Time;
 
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class AddConsultCommandParser implements Parser<AddConsultCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-            PREFIX_EMAIL, PREFIX_COURSE);
+    public AddConsultCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_TIME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!argMultimap.arePrefixesPresent(PREFIX_DATE, PREFIX_TIME)
             || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddConsultCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE, PREFIX_TIME);
+        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Time time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
 
-        // Parse courses; if none are provided, use an empty set
-        Set<Course> courseList = parseCourses(argMultimap.getAllValues(PREFIX_COURSE)).orElse(new HashSet<>());
+        Consultation consult = new Consultation(date, time, List.of());
 
-        Student student = new Student(name, phone, email, courseList);
-
-        return new AddCommand(student);
-    }
-
-    /**
-     * Parses {@code Collection<String> courses} into a {@code Set<Course>} if {@code courses} is non-empty.
-     * This method supports both CSV input and multiple `c/` prefixes.
-     */
-    private Optional<Set<Course>> parseCourses(Collection<String> courses) throws ParseException {
-        assert courses != null;
-
-        if (courses.isEmpty()) {
-            return Optional.empty(); // If no courses are provided, return empty Optional
-        }
-
-        Set<String> parsedCourses = new HashSet<>();
-
-        // For each course string (this could be a CSV or a single course)
-        for (String courseString : courses) {
-
-            List<String> splitCourses = ArgumentTokenizer.tokenizeWithDefault(courseString);
-            // Add each course after trimming whitespace
-            for (String course : splitCourses) {
-                parsedCourses.add(course.trim());
-            }
-        }
-
-        return Optional.of(ParserUtil.parseCourses(parsedCourses));
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argMultimap.getValue(prefix).isPresent());
+        return new AddConsultCommand(consult);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,19 +3,23 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.UniqueStudentList;
 
 /**
  * Wraps all data at the address-book level
- * Duplicates are not allowed (by .isSameStudent comparison)
+ * Duplicate students are not allowed (by .isSameStudent comparison)
  */
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueStudentList students;
+    private final ObservableList<Consultation> consults;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,12 +30,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         students = new UniqueStudentList();
+        consults = FXCollections.observableArrayList();
     }
 
     public AddressBook() {}
 
     /**
-     * Creates an AddressBook using the Students in the {@code toBeCopied}
+     * Creates an AddressBook using the data in the {@code toBeCopied}
      */
     public AddressBook(ReadOnlyAddressBook toBeCopied) {
         this();
@@ -49,12 +54,20 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the consultation list with {@code consults}.
+     */
+    public void setConsults(List<Consultation> consults) {
+        this.consults.setAll(consults);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
         setStudents(newData.getStudentList());
+        setConsults(newData.getConsultList());
     }
 
     //// student-level operations
@@ -73,6 +86,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addStudent(Student p) {
         students.add(p);
+    }
+
+    /**
+     * Adds a consultation to TAHub.
+     */
+    public void addConsult(Consultation c) {
+        consults.add(c);
     }
 
     /**
@@ -101,12 +121,17 @@ public class AddressBook implements ReadOnlyAddressBook {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("students", students)
+                .add("consults", consults)
                 .toString();
     }
 
     @Override
     public ObservableList<Student> getStudentList() {
         return students.asUnmodifiableObservableList();
+    }
+
+    public ObservableList<Consultation> getConsultList() {
+        return FXCollections.unmodifiableObservableList(consults);
     }
 
     @Override
@@ -121,11 +146,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
 
         AddressBook otherAddressBook = (AddressBook) other;
-        return students.equals(otherAddressBook.students);
+        return students.equals(otherAddressBook.students)
+                && consults.equals(otherAddressBook.consults);
     }
 
     @Override
     public int hashCode() {
-        return students.hashCode();
+        return Objects.hash(students, consults);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -81,6 +81,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a consult with the same details as the given consult exists in TAHub.
+     * @param consult The consultation to search for.
+     * @return True if a consultation is found.
+     */
+    public boolean hasConsult(Consultation consult) {
+        requireNonNull(consult);
+        return consults.contains(consult);
+    }
+
+    /**
      * Adds a student to the address book.
      * The student must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -92,4 +92,10 @@ public interface Model {
      * @param consult Consultation to be added.
      */
     void addConsult(Consultation consult);
+
+    /**
+     * Returns true if a student with the same identity as {@code student} exists in the address book.
+     * Returns true if a consultation with the same details as {@code consult} exists in TAHub.
+     */
+    boolean hasConsult(Consultation consult);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 
 /**
@@ -85,4 +86,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredStudentList(Predicate<Student> predicate);
+
+    /**
+     * Adds the given consult.
+     * @param consult Consultation to be added.
+     */
+    void addConsult(Consultation consult);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -153,4 +153,9 @@ public class ModelManager implements Model {
         addressBook.addConsult(consult);
     }
 
+    @Override
+    public boolean hasConsult(Consultation consult) {
+        return addressBook.hasConsult(consult);
+    }
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 
 /**
@@ -143,6 +144,13 @@ public class ModelManager implements Model {
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredStudents.equals(otherModelManager.filteredStudents);
+    }
+
+    // ========== Consultation Commands ==========
+
+    @Override
+    public void addConsult(Consultation consult) {
+        addressBook.addConsult(consult);
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 
 /**
@@ -13,5 +14,11 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate students.
      */
     ObservableList<Student> getStudentList();
+
+    /**
+     * Returns an unmodifiable view of the consults list.
+     * This list will not contain any duplicate students.
+     */
+    ObservableList<Consultation> getConsultList();
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 import seedu.address.testutil.StudentBuilder;
 
@@ -155,6 +156,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredStudentList(Predicate<Student> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addConsult(Consultation consult) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -7,23 +7,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalStudents.ALICE;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
+import seedu.address.testutil.ModelStub;
 import seedu.address.testutil.StudentBuilder;
 
 public class AddCommandTest {
@@ -83,86 +77,6 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(ALICE);
         String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addStudent(Student student) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasStudent(Student student) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteStudent(Student target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setStudent(Student target, Student editedStudent) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Student> getFilteredStudentList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredStudentList(Predicate<Student> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addConsult(Consultation consult) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/consultation/AddConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/AddConsultCommandTest.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands.consultation;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.consultation.Consultation;
+import seedu.address.testutil.ConsultationBuilder;
+import seedu.address.testutil.ModelStub;
+
+public class AddConsultCommandTest {
+
+    @Test
+    public void constructor_nullStudent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddConsultCommand(null));
+    }
+
+    @Test
+    public void execute_consultAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingConsultAdded modelStub = new ModelStubAcceptingConsultAdded();
+        Consultation consult = new ConsultationBuilder().build();
+        CommandResult commandResult = new AddConsultCommand(consult).execute(modelStub);
+
+        assertEquals(String.format(AddConsultCommand.MESSAGE_SUCCESS, Messages.format(consult)),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(consult), modelStub.consultsAdded);
+    }
+
+    @Test
+    public void equals() {
+        Consultation jan1stConsult = new ConsultationBuilder().withDate("2024-01-01").build();
+        Consultation feb2ndConsult = new ConsultationBuilder().withDate("2024-02-02").build();
+
+        AddConsultCommand addJan1stConsult = new AddConsultCommand(jan1stConsult);
+        AddConsultCommand addFeb2ndConsult = new AddConsultCommand(feb2ndConsult);
+
+        // same object -> returns true
+        assertTrue(addJan1stConsult.equals(addJan1stConsult));
+
+        // same values -> returns true
+        AddConsultCommand addJan1stConsultCopy = new AddConsultCommand(jan1stConsult);
+        assertTrue(addJan1stConsult.equals(addJan1stConsultCopy));
+
+        // different types -> returns false
+        assertFalse(addJan1stConsult.equals(1));
+
+        // null -> returns false
+        assertFalse(addJan1stConsult.equals(null));
+
+        // different student -> returns false
+        assertFalse(addJan1stConsult.equals(addFeb2ndConsult));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Consultation consult = new ConsultationBuilder().build();
+        AddConsultCommand addConsultCommand = new AddConsultCommand(consult);
+        String expected = AddConsultCommand.class.getCanonicalName() + "{newConsult=" + consult + "}";
+        assertEquals(expected, addConsultCommand.toString());
+    }
+
+    /**
+     * A Model stub that always accept the consult being added.
+     */
+    private class ModelStubAcceptingConsultAdded extends ModelStub {
+        final ArrayList<Consultation> consultsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasConsult(Consultation consult) {
+            requireNonNull(consult);
+            return consultsAdded.stream().anyMatch(consult::equals);
+        }
+
+        @Override
+        public void addConsult(Consultation consult) {
+            requireNonNull(consult);
+            consultsAdded.add(consult);
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            return new AddressBook();
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,10 +23,13 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.consultation.AddConsultCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.IsStudentOfCoursePredicate;
 import seedu.address.model.student.NameContainsKeywordsPredicate;
 import seedu.address.model.student.Student;
+import seedu.address.testutil.ConsultationBuilder;
 import seedu.address.testutil.EditStudentDescriptorBuilder;
 import seedu.address.testutil.StudentBuilder;
 import seedu.address.testutil.StudentUtil;
@@ -41,6 +44,14 @@ public class AddressBookParserTest {
         Student student = new StudentBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(StudentUtil.getAddCommand(student));
         assertEquals(new AddCommand(student), command);
+    }
+
+    @Test
+    public void parseCommand_addConsult() throws Exception {
+        Consultation consult = new ConsultationBuilder().build();
+        AddConsultCommand command = (AddConsultCommand) parser.parseCommand(
+                AddConsultCommand.COMMAND_WORD + " d/" + consult.getDate() + " t/" + consult.getTime());
+        assertEquals(new AddConsultCommand(consult), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/consultation/AddConsultCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/consultation/AddConsultCommandParserTest.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.parser.consultation;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.consultation.AddConsultCommand;
+import seedu.address.model.consultation.Consultation;
+import seedu.address.model.consultation.Date;
+import seedu.address.model.consultation.Time;
+
+public class AddConsultCommandParserTest {
+    private AddConsultCommandParser parser = new AddConsultCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        AddConsultCommand expectedCommand = new AddConsultCommand(
+                new Consultation(new Date("2024-10-20"), new Time("14:00"), List.of()));
+
+        // no whitespace (besides the first initial blank)
+        assertParseSuccess(parser, " d/2024-10-20 t/14:00", expectedCommand);
+
+        // random whitespace
+        assertParseSuccess(parser, "  \n \t d/2024-10-20 \t\n  t/14:00  \n  ", expectedCommand);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddConsultCommand.MESSAGE_USAGE);
+
+        // missing date prefix
+        assertParseFailure(parser, " t/14:00", expectedMessage);
+
+        // missing time prefix
+        assertParseFailure(parser, " d/2024-10-20", expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, " ", expectedMessage);
+    }
+
+    @Test
+    public void parse_duplicateFields_failure() {
+        // duplicate date prefix
+        assertParseFailure(parser, " d/2024-10-20 t/14:00 d/2024-10-21",
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+
+        // duplicate time prefix
+        assertParseFailure(parser, " d/2024-10-20 t/14:00 t/13:00",
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TIME));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid date
+        assertParseFailure(parser, " d/20-10-2024 t/14:00", Date.MESSAGE_CONSTRAINTS);
+
+        // invalid time
+        assertParseFailure(parser, " d/2024-10-20 t/25:00", Time.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.exceptions.DuplicateStudentException;
 import seedu.address.testutil.StudentBuilder;
@@ -48,7 +49,7 @@ public class AddressBookTest {
         Student editedAlice = new StudentBuilder(ALICE).withCourses(VALID_COURSE_CS2103T)
                 .build();
         List<Student> newStudents = Arrays.asList(ALICE, editedAlice);
-        AddressBookStub newData = new AddressBookStub(newStudents);
+        AddressBookStub newData = new AddressBookStub(newStudents, List.of());
 
         assertThrows(DuplicateStudentException.class, () -> addressBook.resetData(newData));
     }
@@ -84,7 +85,9 @@ public class AddressBookTest {
 
     @Test
     public void toStringMethod() {
-        String expected = AddressBook.class.getCanonicalName() + "{students=" + addressBook.getStudentList() + "}";
+        String expected = AddressBook.class.getCanonicalName()
+                + "{students=" + addressBook.getStudentList()
+                + ", consults=" + addressBook.getConsultList() + "}";
         assertEquals(expected, addressBook.toString());
     }
 
@@ -93,14 +96,21 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Student> students = FXCollections.observableArrayList();
+        private final ObservableList<Consultation> consults = FXCollections.observableArrayList();
 
-        AddressBookStub(Collection<Student> students) {
+        AddressBookStub(Collection<Student> students, Collection<Consultation> consults) {
             this.students.setAll(students);
+            this.consults.setAll(consults);
         }
 
         @Override
         public ObservableList<Student> getStudentList() {
             return students;
+        }
+
+        @Override
+        public ObservableList<Consultation> getConsultList() {
+            return consults;
         }
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -20,6 +20,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.exceptions.DuplicateStudentException;
+import seedu.address.testutil.ConsultationBuilder;
 import seedu.address.testutil.StudentBuilder;
 
 public class AddressBookTest {
@@ -77,6 +78,32 @@ public class AddressBookTest {
                 .build();
         assertTrue(addressBook.hasStudent(editedAlice));
     }
+
+    @Test
+    public void hasConsult_nullConsult_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasConsult(null));
+    }
+
+    @Test
+    public void hasConsult_consultNotInAddressBook_returnsFalse() {
+        assertFalse(addressBook.hasConsult(new ConsultationBuilder().build()));
+    }
+
+    @Test
+    public void hasConsult_consultInAddressBook_returnsTrue() {
+        Consultation consult = new ConsultationBuilder().build();
+        addressBook.addConsult(consult);
+        assertTrue(addressBook.hasConsult(consult));
+    }
+
+    @Test
+    public void hasConsult_consultWithSameDetailsInAddressBook_returnsTrue() {
+        Consultation consult = new ConsultationBuilder().build();
+        Consultation copy = new ConsultationBuilder(consult).build();
+        addressBook.addConsult(consult);
+        assertTrue(addressBook.hasConsult(copy));
+    }
+
 
     @Test
     public void getStudentList_modifyList_throwsUnsupportedOperationException() {

--- a/src/test/java/seedu/address/testutil/ConsultationBuilder.java
+++ b/src/test/java/seedu/address/testutil/ConsultationBuilder.java
@@ -1,0 +1,60 @@
+package seedu.address.testutil;
+
+import java.util.List;
+
+import seedu.address.model.consultation.Consultation;
+import seedu.address.model.consultation.Date;
+import seedu.address.model.consultation.Time;
+import seedu.address.model.student.Student;
+
+/**
+ * A utility class to help with building Consultation objects.
+ */
+public class ConsultationBuilder {
+
+    public static final String DEFAULT_DATE = "2024-10-20";
+    public static final String DEFAULT_TIME = "14:00";
+    public static final String DEFAULT_NAMES = "";
+    private Date date;
+    private Time time;
+    private List<Student> students;
+
+    /**
+     * Creates a {@code ConsultationBuilder} with the default details.
+     */
+    public ConsultationBuilder() {
+        date = new Date(DEFAULT_DATE);
+        time = new Time(DEFAULT_TIME);
+        students = List.of();
+    }
+
+    /**
+     * Initializes the StudentBuilder with the data of {@code consultationToCopy}.
+     */
+    public ConsultationBuilder(Consultation consultationToCopy) {
+        date = consultationToCopy.getDate();
+        time = consultationToCopy.getTime();
+        students = consultationToCopy.getStudents();
+    }
+
+    /**
+     * Sets the {@code Date} of the {@code Consultation} that we are building.
+     */
+    public ConsultationBuilder withDate(String date) {
+        this.date = new Date(date);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Time} of the {@code Consultation} that we are building.
+     */
+    public ConsultationBuilder withTime(String time) {
+        this.time = new Time(time);
+        return this;
+    }
+
+    public Consultation build() {
+        return new Consultation(date, time, students);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -1,0 +1,97 @@
+package seedu.address.testutil;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.consultation.Consultation;
+import seedu.address.model.student.Student;
+
+/**
+ * A default model stub that have all the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addStudent(Student student) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasStudent(Student student) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteStudent(Student target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setStudent(Student target, Student editedStudent) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Student> getFilteredStudentList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredStudentList(Predicate<Student> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addConsult(Consultation consult) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasConsult(Consultation consult) {
+        throw new AssertionError("This method should not be called.");
+    }
+}


### PR DESCRIPTION
Closes #96.

This PR:
- Implements the `addconsult` command. Syntax: `addconsult d/date t/time`. Immediate adding of students is not supported but may be implemented in the future.
- Updates existing and adds new testcases to cover the new `AddConsultCommand`, `AddConsultCommandParser` and their dependencies.

It does NOT:
- Update the `Storage` component to save `Consultation` details after the application is closed. This will be handled in another PR.