### PR TITLE
Add deleteconsult command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,7 +17,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX =
             "The student provided at index %1$d is invalid";
-    public static final String MESSAGE_INVALID_INDEX_SHOWN = "The student provided at index/indices %1$s is invalid";
+    public static final String MESSAGE_INVALID_INDEX_SHOWN = "The target provided at index/indices %1$s is invalid";
     public static final String MESSAGE_STUDENTS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -54,7 +54,7 @@ public class CommandResult {
     public CommandResult(String feedbackToUser) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.commandType = null;
-        this.tabIndex = null;;
+        this.tabIndex = null;
     }
 
     public String getFeedbackToUser() {
@@ -65,7 +65,9 @@ public class CommandResult {
         return commandType;
     }
 
-    public Index getTabIndex() { return tabIndex; }
+    public Index getTabIndex() {
+        return tabIndex;
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/consultation/DeleteConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/DeleteConsultCommand.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands.consultation;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.consultation.Consultation;
+
+/**
+ * Deletes a consultation by its index in TAHub.
+ */
+public class DeleteConsultCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteconsult";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the consultation identified by the index number used in the displayed consultation list.\n"
+            + "Parameters: INDEX (must be a positive integer) [;INDEX...]\n"
+            + "Example: " + COMMAND_WORD + " 1" + DEFAULT_DELIMITER + "2";
+
+    public static final String MESSAGE_DELETE_CONSULT_SUCCESS = "Deleted Consult(s):\n%1$s";
+
+    private final Set<Index> targetIndices;
+
+    public DeleteConsultCommand(Set<Index> targetIndices) {
+        this.targetIndices = targetIndices;
+    }
+
+    /**
+     * Returns Command Type DELETECONSULT
+     *
+     * @return Command Type DELETECONSULT
+     */
+    @Override
+    public CommandType getCommandType() {
+        return CommandType.DELETECONSULT;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Consultation> consults = model.getConsultList();
+
+        boolean throwException = false;
+        ArrayList<Index> outOfBounds = new ArrayList<>();
+
+        for (Index item: targetIndices) {
+            if (item.getZeroBased() >= consults.size()) {
+                throwException = true;
+                outOfBounds.add(item);
+            }
+        }
+
+        if (throwException) {
+            String formattedOutOfBoundIndices = outOfBounds.stream()
+                    .map(index -> String.valueOf(index.getOneBased()))
+                    .collect(Collectors.joining(", "));
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN, formattedOutOfBoundIndices));
+        }
+
+        List<Consultation> deletedPeople = targetIndices.stream()
+                .map(targetIndex -> consults.get(targetIndex.getZeroBased()))
+                .toList();
+
+
+        deletedPeople.forEach(model::deleteConsult);
+
+        String formattedDeletedPeople = deletedPeople.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining("\n"));
+
+
+        return new CommandResult(String.format(MESSAGE_DELETE_CONSULT_SUCCESS, formattedDeletedPeople));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteConsultCommand)) {
+            return false;
+        }
+
+        DeleteConsultCommand otherDeleteCommand = (DeleteConsultCommand) other;
+        return targetIndices.equals(otherDeleteCommand.targetIndices);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndices", targetIndices)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/consultation/DeleteConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/DeleteConsultCommand.java
@@ -51,7 +51,7 @@ public class DeleteConsultCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Consultation> consults = model.getConsultList();
+        List<Consultation> consults = model.getFilteredConsultationList();
 
         boolean throwException = false;
         ArrayList<Index> outOfBounds = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,7 +19,9 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.consultation.AddConsultCommand;
+import seedu.address.logic.commands.consultation.DeleteConsultCommand;
 import seedu.address.logic.parser.consultation.AddConsultCommandParser;
+import seedu.address.logic.parser.consultation.DeleteConsultCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +69,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteConsultCommand.COMMAND_WORD:
+            return new DeleteConsultCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/consultation/DeleteConsultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultation/DeleteConsultCommandParser.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.parser.consultation;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.consultation.DeleteConsultCommand;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Parses input arguments and creates a new DeleteConsultCommand object
+ */
+public class DeleteConsultCommandParser implements Parser<DeleteConsultCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteConsultCommand
+     * and returns a DeleteConsultCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public DeleteConsultCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        List<String> indicesList = ArgumentTokenizer.tokenizeWithDefault(args);
+        if (indicesList.isEmpty() || indicesList.stream().anyMatch(String::isEmpty)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+        }
+
+
+        try {
+            Set<Index> indices;
+            Optional<Set<Index>> optionalIndices = parseIndicesForDelete(indicesList);
+            assert optionalIndices.isPresent() : "Optional set of indices should not be empty or return null";
+            indices = optionalIndices.get();
+            return new DeleteConsultCommand(indices);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments and returns an optional set of Index objects.
+     * @param indices A collection of Strings representing indices
+     * @return An optional set which contains Index objects
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private Optional<Set<Index>> parseIndicesForDelete(Collection<String> indices) throws ParseException {
+        assert indices != null;
+
+        if (indices.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> indicesSet = indices.size() == 1 && indices.contains("") ? Collections.emptySet() : indices;
+        return Optional.of(ParserUtil.parseIndices(indicesSet));
+    }
+
+
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -125,6 +125,16 @@ public class AddressBook implements ReadOnlyAddressBook {
         students.remove(key);
     }
 
+    /**
+     * Removes {@code consult} from this {@code AddressBook}.
+     * {@code consult} must exist in TAHub.
+     *
+     * @param consult The consult to be removed.
+     */
+    public void removeConsult(Consultation consult) {
+        consults.remove(consult);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -94,8 +94,17 @@ public interface Model {
     void addConsult(Consultation consult);
 
     /**
+     * Deletes the given consultation.
+     * The consultation must exist in TAHub.
+     */
+    void deleteConsult(Consultation consult);
+
+    /**
      * Returns true if a student with the same identity as {@code student} exists in the address book.
      * Returns true if a consultation with the same details as {@code consult} exists in TAHub.
      */
     boolean hasConsult(Consultation consult);
+
+    /** Returns an unmodifiable view of the consult list */
+    ObservableList<Consultation> getConsultList();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Student> filteredStudents;
+    private final FilteredList<Consultation> filteredConsults;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredStudents = new FilteredList<>(this.addressBook.getStudentList());
+        filteredConsults = new FilteredList<>(this.addressBook.getConsultList());
     }
 
     public ModelManager() {
@@ -154,8 +156,18 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteConsult(Consultation consult) {
+        addressBook.removeConsult(consult);
+    }
+
+    @Override
     public boolean hasConsult(Consultation consult) {
         return addressBook.hasConsult(consult);
+    }
+
+    @Override
+    public ObservableList<Consultation> getConsultList() {
+        return filteredConsults;
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -11,9 +11,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_STUDENTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalStudents.BENSON;
 import static seedu.address.testutil.TypicalStudents.DANIEL;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -3,8 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/consultation/DeleteConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/DeleteConsultCommandTest.java
@@ -33,7 +33,7 @@ public class DeleteConsultCommandTest {
     @Test
     public void execute_validIndex_success() {
         Index firstIndex = Index.fromOneBased(1);
-        Consultation consultToDelete = model.getConsultList().get(firstIndex.getZeroBased());
+        Consultation consultToDelete = model.getFilteredConsultationList().get(firstIndex.getZeroBased());
         Set<Index> firstIndexSet = new HashSet<>();
         firstIndexSet.add(firstIndex);
         DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(firstIndexSet);
@@ -52,8 +52,8 @@ public class DeleteConsultCommandTest {
         ArrayList<Consultation> consultsToDelete = new ArrayList<>();
         Index firstIndex = Index.fromOneBased(1);
         Index thirdIndex = Index.fromOneBased(3);
-        consultsToDelete.add(model.getConsultList().get(firstIndex.getZeroBased()));
-        consultsToDelete.add(model.getConsultList().get(thirdIndex.getZeroBased()));
+        consultsToDelete.add(model.getFilteredConsultationList().get(firstIndex.getZeroBased()));
+        consultsToDelete.add(model.getFilteredConsultationList().get(thirdIndex.getZeroBased()));
 
 
         Set<Index> indexSet = new HashSet<>();
@@ -75,8 +75,8 @@ public class DeleteConsultCommandTest {
 
     @Test
     public void execute_allInvalidIndex_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getConsultList().size() + 1);
-        Index outOfBoundIndex2 = Index.fromOneBased(model.getConsultList().size() + 2);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredConsultationList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredConsultationList().size() + 2);
         Set<Index> outOfBoundIndexSet = new HashSet<>();
         outOfBoundIndexSet.add(outOfBoundIndex);
         outOfBoundIndexSet.add(outOfBoundIndex2);
@@ -91,8 +91,8 @@ public class DeleteConsultCommandTest {
 
     @Test
     public void execute_someInvalidIndex_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getConsultList().size() + 1);
-        Index outOfBoundIndex2 = Index.fromOneBased(model.getConsultList().size() + 2);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredConsultationList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getFilteredConsultationList().size() + 2);
 
         Set<Index> outOfBoundIndexSet = new HashSet<>();
         outOfBoundIndexSet.add(outOfBoundIndex);
@@ -109,7 +109,7 @@ public class DeleteConsultCommandTest {
 
     @Test
     public void execute_oneOfOneInvalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getConsultList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredConsultationList().size() + 1);
         Set<Index> outOfBoundIndexSet = new HashSet<>();
         outOfBoundIndexSet.add(outOfBoundIndex);
         outOfBoundIndexSet.add(Index.fromOneBased(1));

--- a/src/test/java/seedu/address/logic/commands/consultation/DeleteConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/DeleteConsultCommandTest.java
@@ -1,0 +1,171 @@
+package seedu.address.logic.commands.consultation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.consultation.Consultation;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteCommand}.
+ */
+public class DeleteConsultCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndex_success() {
+        Index firstIndex = Index.fromOneBased(1);
+        Consultation consultToDelete = model.getConsultList().get(firstIndex.getZeroBased());
+        Set<Index> firstIndexSet = new HashSet<>();
+        firstIndexSet.add(firstIndex);
+        DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(firstIndexSet);
+
+        String expectedMessage = String.format(DeleteConsultCommand.MESSAGE_DELETE_CONSULT_SUCCESS,
+                Messages.format(consultToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteConsult(consultToDelete);
+
+        assertCommandSuccess(deleteConsultCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleValidIndex_success() {
+        ArrayList<Consultation> consultsToDelete = new ArrayList<>();
+        Index firstIndex = Index.fromOneBased(1);
+        Index thirdIndex = Index.fromOneBased(3);
+        consultsToDelete.add(model.getConsultList().get(firstIndex.getZeroBased()));
+        consultsToDelete.add(model.getConsultList().get(thirdIndex.getZeroBased()));
+
+
+        Set<Index> indexSet = new HashSet<>();
+        indexSet.add(firstIndex);
+        indexSet.add(thirdIndex);
+        DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(indexSet);
+
+        String formattedDeletedConsults = consultsToDelete.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining("\n"));
+        String expectedMessage = String.format(DeleteConsultCommand.MESSAGE_DELETE_CONSULT_SUCCESS,
+                formattedDeletedConsults);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        consultsToDelete.forEach(expectedModel::deleteConsult);
+
+        assertCommandSuccess(deleteConsultCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_allInvalidIndex_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getConsultList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getConsultList().size() + 2);
+        Set<Index> outOfBoundIndexSet = new HashSet<>();
+        outOfBoundIndexSet.add(outOfBoundIndex);
+        outOfBoundIndexSet.add(outOfBoundIndex2);
+        DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(outOfBoundIndexSet);
+
+        String formattedOutOfBoundIndices = outOfBoundIndex.getOneBased() + ", " + outOfBoundIndex2.getOneBased();
+
+
+        assertCommandFailure(deleteConsultCommand, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                formattedOutOfBoundIndices));
+    }
+
+    @Test
+    public void execute_someInvalidIndex_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getConsultList().size() + 1);
+        Index outOfBoundIndex2 = Index.fromOneBased(model.getConsultList().size() + 2);
+
+        Set<Index> outOfBoundIndexSet = new HashSet<>();
+        outOfBoundIndexSet.add(outOfBoundIndex);
+        outOfBoundIndexSet.add(Index.fromOneBased(1));
+        outOfBoundIndexSet.add(outOfBoundIndex2);
+
+        DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(outOfBoundIndexSet);
+
+        String formattedOutOfBoundIndices = outOfBoundIndex.getOneBased() + ", " + outOfBoundIndex2.getOneBased();
+
+        assertCommandFailure(deleteConsultCommand, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                formattedOutOfBoundIndices));
+    }
+
+    @Test
+    public void execute_oneOfOneInvalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getConsultList().size() + 1);
+        Set<Index> outOfBoundIndexSet = new HashSet<>();
+        outOfBoundIndexSet.add(outOfBoundIndex);
+        outOfBoundIndexSet.add(Index.fromOneBased(1));
+        DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(outOfBoundIndexSet);
+
+        assertCommandFailure(deleteConsultCommand, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                String.valueOf(outOfBoundIndex.getOneBased())));
+    }
+
+    @Test
+    public void equals() {
+        // create commands
+        Index firstIndex = Index.fromOneBased(1);
+        Index secondIndex = Index.fromOneBased(2);
+        Set<Index> firstIndexSet = new HashSet<>();
+        firstIndexSet.add(firstIndex);
+        Set<Index> secondIndexSet = new HashSet<>();
+        secondIndexSet.add(secondIndex);
+        DeleteConsultCommand deleteFirstCommand = new DeleteConsultCommand(firstIndexSet);
+        DeleteConsultCommand deleteSecondCommand = new DeleteConsultCommand(secondIndexSet);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        Set<Index> firstIndexSetCopy = new HashSet<>();
+        firstIndexSetCopy.add(firstIndex);
+        DeleteConsultCommand deleteFirstCommandCopy = new DeleteConsultCommand(firstIndexSetCopy);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different student -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        Set<Index> targetIndexSet = new HashSet<>();
+        targetIndexSet.add(targetIndex);
+        DeleteConsultCommand deleteConsultCommand = new DeleteConsultCommand(targetIndexSet);
+        String expected = DeleteConsultCommand.class.getCanonicalName() + "{targetIndices=" + targetIndexSet + "}";
+        assertEquals(expected, deleteConsultCommand.toString());
+    }
+
+    @Test
+    public void getCommandTypeMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        Set<Index> targetIndexSet = new HashSet<>();
+        targetIndexSet.add(targetIndex);
+        DeleteConsultCommand deleteCommand = new DeleteConsultCommand(targetIndexSet);
+        assertEquals(deleteCommand.getCommandType(), CommandType.DELETECONSULT);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONSULT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import java.nio.file.Paths;
@@ -26,6 +27,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.consultation.AddConsultCommand;
+import seedu.address.logic.commands.consultation.DeleteConsultCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.IsStudentOfCoursePredicate;
@@ -69,6 +71,15 @@ public class AddressBookParserTest {
         Set<Index> firstIndexSet = new HashSet<>();
         firstIndexSet.add(INDEX_FIRST_STUDENT);
         assertEquals(new DeleteCommand(firstIndexSet), command);
+    }
+
+    @Test
+    public void parseCommand_deleteConsult() throws Exception {
+        DeleteConsultCommand command = (DeleteConsultCommand) parser.parseCommand(
+                DeleteConsultCommand.COMMAND_WORD + " " + INDEX_FIRST_CONSULT.getOneBased());
+        Set<Index> firstIndexSet = new HashSet<>();
+        firstIndexSet.add(INDEX_FIRST_CONSULT);
+        assertEquals(new DeleteConsultCommand(firstIndexSet), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/consultation/DeleteConsultCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/consultation/DeleteConsultCommandParserTest.java
@@ -1,0 +1,99 @@
+package seedu.address.logic.parser.consultation;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.DEFAULT_DELIMITER;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONSULT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CONSULT;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.consultation.DeleteConsultCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside the DeleteConsultCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteConsultCommandParserTest {
+
+    private DeleteConsultCommandParser parser = new DeleteConsultCommandParser();
+
+    @Test
+    public void parse_singleDeleteValidArgs_returnsDeleteCommand() {
+        Set<Index> firstIndexSet = new HashSet<>();
+        firstIndexSet.add(INDEX_FIRST_CONSULT);
+        assertParseSuccess(parser, "1", new DeleteConsultCommand(firstIndexSet));
+    }
+
+    @Test
+    public void parse_multiDeleteValidArgs_returnsDeleteCommand() {
+        Set<Index> indexSet = new HashSet<>();
+        indexSet.add(INDEX_FIRST_CONSULT);
+        indexSet.add(INDEX_SECOND_CONSULT);
+        assertParseSuccess(parser, "1" + DEFAULT_DELIMITER + " 2",
+                new DeleteConsultCommand(indexSet));
+    }
+
+    @Test
+    public void parse_noArgs_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsNotNum_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_someValidSomeInvalidArgsNotNum_throwsParseException() {
+        assertParseFailure(parser, "1" + DEFAULT_DELIMITER + " a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsOnlyDelimiter_throwsParseException() {
+        assertParseFailure(parser, DEFAULT_DELIMITER.toString(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsEmptyString_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsOneEmptyString_throwsParseException() {
+        assertParseFailure(parser, "2 " + DEFAULT_DELIMITER + " 1" + DEFAULT_DELIMITER,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsAllEmptyString_throwsParseException() {
+        assertParseFailure(parser, "" + DEFAULT_DELIMITER + DEFAULT_DELIMITER,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsSomeEmptyString_throwsParseException() {
+        assertParseFailure(parser, DEFAULT_DELIMITER + "3" + DEFAULT_DELIMITER,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgsSpaces_throwsParseException() {
+        assertParseFailure(parser, " " + DEFAULT_DELIMITER + " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteConsultCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_CS2103T;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalStudents.ALICE;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -6,7 +6,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalStudents.ALICE;
 import static seedu.address.testutil.TypicalStudents.HOON;
 import static seedu.address.testutil.TypicalStudents.IDA;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalStudents.getTypicalStudentOnlyAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -63,7 +63,7 @@ public class JsonAddressBookStorageTest {
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempAddressBook.json");
-        AddressBook original = getTypicalAddressBook();
+        AddressBook original = getTypicalStudentOnlyAddressBook();
         JsonAddressBookStorage jsonAddressBookStorage = new JsonAddressBookStorage(filePath);
 
         // Save in new file and read back

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalStudents.getTypicalStudentOnlyAddressBook;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
-import seedu.address.testutil.TypicalStudents;
 
 public class JsonSerializableAddressBookTest {
 
@@ -25,7 +25,7 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_STUDENTS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalStudentsAddressBook = TypicalStudents.getTypicalAddressBook();
+        AddressBook typicalStudentsAddressBook = getTypicalStudentOnlyAddressBook();
         assertEquals(addressBookFromFile, typicalStudentsAddressBook);
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,7 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.address.testutil.TypicalStudents.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalStudents.getTypicalStudentOnlyAddressBook;
 
 import java.nio.file.Path;
 
@@ -54,7 +54,7 @@ public class StorageManagerTest {
          * {@link JsonAddressBookStorage} class.
          * More extensive testing of UserPref saving/reading is done in {@link JsonAddressBookStorageTest} class.
          */
-        AddressBook original = getTypicalAddressBook();
+        AddressBook original = getTypicalStudentOnlyAddressBook();
         storageManager.saveAddressBook(original);
         ReadOnlyAddressBook retrieved = storageManager.readAddressBook().get();
         assertEquals(original, new AddressBook(retrieved));

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -86,7 +86,17 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public ObservableList<Consultation> getConsultList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void addConsult(Consultation consult) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteConsult(Consultation consult) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -89,11 +89,6 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public ObservableList<Consultation> getConsultList() {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
     public void addConsult(Consultation consult) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/testutil/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/TypicalAddressBook.java
@@ -1,0 +1,30 @@
+package seedu.address.testutil;
+
+import static seedu.address.testutil.TypicalConsults.getTypicalConsults;
+import static seedu.address.testutil.TypicalStudents.getTypicalStudents;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.consultation.Consultation;
+import seedu.address.model.student.Student;
+
+/**
+ * A utility class containing a typical AddressBook with sample data for testing.
+ */
+public class TypicalAddressBook {
+
+    private TypicalAddressBook() {} // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with typical students and consults.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Student student : getTypicalStudents()) {
+            ab.addStudent(student);
+        }
+        for (Consultation consult : getTypicalConsults()) {
+            ab.addConsult(consult);
+        }
+        return ab;
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalConsults.java
+++ b/src/test/java/seedu/address/testutil/TypicalConsults.java
@@ -1,0 +1,35 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.consultation.Consultation;
+
+/**
+ * A utility class containing a list of {@code Consultation} objects to be used in tests.
+ */
+public class TypicalConsults {
+
+    public static final Consultation CONSULT_1 = new ConsultationBuilder()
+            .withDate("2024-10-21")
+            .withTime("10:00").build();
+    public static final Consultation CONSULT_2 = new ConsultationBuilder()
+            .withDate("2024-10-23")
+            .withTime("10:30").build();
+    public static final Consultation CONSULT_3 = new ConsultationBuilder()
+            .withDate("2024-10-25")
+            .withTime("11:30").build();
+    public static final Consultation CONSULT_4 = new ConsultationBuilder()
+            .withDate("2024-10-27")
+            .withTime("13:00").build();
+    public static final Consultation CONSULT_5 = new ConsultationBuilder()
+            .withDate("2024-10-29")
+            .withTime("15:30").build();
+
+    private TypicalConsults() {} // prevents instantiation
+
+    public static List<Consultation> getTypicalConsults() {
+        return new ArrayList<>(Arrays.asList(CONSULT_1, CONSULT_2, CONSULT_3, CONSULT_4, CONSULT_5));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,14 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_STUDENT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_STUDENT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_STUDENT = Index.fromOneBased(3);
+
+    /**
+     * We separate Student indexes from Consult indexes in case the number of sample data is
+     * vastly different in the future such that indexes for students may not be valid for consults
+     * and vice versa.
+     */
+
+    public static final Index INDEX_FIRST_CONSULT = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_CONSULT = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_CONSULT = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -56,18 +56,18 @@ public class TypicalStudents {
 
     private TypicalStudents() {} // prevents instantiation
 
+    public static List<Student> getTypicalStudents() {
+        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
     /**
-     * Returns an {@code AddressBook} with all the typical students.
+     * Returns an {@code AddressBook} with typical students only.
      */
-    public static AddressBook getTypicalAddressBook() {
+    public static AddressBook getTypicalStudentOnlyAddressBook() {
         AddressBook ab = new AddressBook();
         for (Student student : getTypicalStudents()) {
             ab.addStudent(student);
         }
         return ab;
-    }
-
-    public static List<Student> getTypicalStudents() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
     }
 }


### PR DESCRIPTION
Closes #99.

This PR:
- Implements the `deleteconsult` method, which is functionally similar to the `delete` command except that it targets the consultation list.
- Adds new testcases adapted from the existing extensive ones for `DeleteCommand`.

Note:
- There is currently no way to, nor are there plans to (as of yet) add the ability to filter consultations. However, should this feature be added in the future, code can simply be adapted from `DeleteCommand`.