### PR TITLE
Fix export command to check extension and existing file

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -29,9 +29,12 @@ public class ExportCommandParser implements Parser<ExportCommand> {
         String filename = trimmedArgs;
 
         // Check if force flag is present
-        if (trimmedArgs.startsWith(ExportCommand.FORCE_FLAG + " ")) {
+        if (trimmedArgs.equals(ExportCommand.FORCE_FLAG)
+                || trimmedArgs.startsWith(ExportCommand.FORCE_FLAG + " ")) {
             isForceExport = true;
-            filename = trimmedArgs.substring(ExportCommand.FORCE_FLAG.length()).trim();
+            // Extract filename after the force flag and space
+            filename = trimmedArgs.equals(ExportCommand.FORCE_FLAG) ? ""
+                    : trimmedArgs.substring(ExportCommand.FORCE_FLAG.length()).trim();
         }
 
         // Validate filename

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -2,9 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -12,6 +9,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new ExportCommand object
  */
 public class ExportCommandParser implements Parser<ExportCommand> {
+    public static final String MESSAGE_INVALID_FILENAME =
+            "Filename cannot contain periods or slashes. Please provide a simple filename.";
+    private static final String INVALID_FILENAME_CHARS = "[./\\\\]";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ExportCommand
@@ -25,7 +25,25 @@ public class ExportCommandParser implements Parser<ExportCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }
 
-        Path filePath = Paths.get(trimmedArgs);
-        return new ExportCommand(filePath);
+        boolean isForceExport = false;
+        String filename = trimmedArgs;
+
+        // Check if force flag is present
+        if (trimmedArgs.startsWith(ExportCommand.FORCE_FLAG + " ")) {
+            isForceExport = true;
+            filename = trimmedArgs.substring(ExportCommand.FORCE_FLAG.length()).trim();
+        }
+
+        // Validate filename
+        if (filename.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+
+        if (filename.matches(".*" + INVALID_FILENAME_CHARS + ".*")) {
+            throw new ParseException(MESSAGE_INVALID_FILENAME);
+        }
+
+        return new ExportCommand(filename, isForceExport);
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -185,6 +185,9 @@ public class LogicManagerTest {
 
     @Test
     public void execute_exportCommand_success() throws Exception {
+        // Create data directory path in temporary folder
+        Path dataDir = temporaryFolder.resolve("data");
+
         // Add a sample student to the model
         Student sampleStudent = new StudentBuilder().withName("John Doe")
                 .withPhone("12345678")
@@ -192,19 +195,23 @@ public class LogicManagerTest {
                 .withCourses("CS2103T").build();
         model.addStudent(sampleStudent);
 
-        String exportCommand = ExportCommand.COMMAND_WORD + " " + temporaryFolder.resolve("export.csv").toString();
-        assertCommandSuccess(exportCommand, String.format(
-                ExportCommand.MESSAGE_SUCCESS,
-                1,
-                temporaryFolder.resolve("export.csv")),
-                model);
+        String filename = "export";
+        // Create the command with the temporary directory
+        ExportCommand exportCommand = new ExportCommand(filename, false, dataDir);
+
+        // Execute the command directly
+        CommandResult result = exportCommand.execute(model);
+
+        // Verify the result message
+        Path expectedPath = dataDir.resolve(filename + ".csv");
+        assertEquals(String.format(ExportCommand.MESSAGE_SUCCESS, 1, expectedPath),
+                result.getFeedbackToUser());
 
         // Verify that the file was created
-        Path exportPath = temporaryFolder.resolve("export.csv");
-        assertTrue(Files.exists(exportPath));
+        assertTrue(Files.exists(expectedPath));
 
         // Verify the content of the exported file
-        List<String> lines = Files.readAllLines(exportPath);
+        List<String> lines = Files.readAllLines(expectedPath);
         assertEquals(2, lines.size()); // Header + 1 student
         assertEquals("Name,Phone,Email,Courses", lines.get(0)); // Verify the header
 
@@ -212,7 +219,9 @@ public class LogicManagerTest {
                 sampleStudent.getName(),
                 sampleStudent.getPhone(),
                 sampleStudent.getEmail(),
-                sampleStudent.getCourses().stream().map(Course::toString).collect(Collectors.joining(";")));
+                sampleStudent.getCourses().stream()
+                        .map(Course::toString)
+                        .collect(Collectors.joining(";")));
         assertEquals(expectedLine, lines.get(1));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -155,4 +155,32 @@ public class ExportCommandTest {
         assertEquals(2, lines.size()); // Header + 1 student
         assertEquals("Name,Phone,Email,Courses", lines.get(0));
     }
+
+    @Test
+    public void execute_directoryCreationFails_throwsCommandException() throws IOException {
+        // Create a read-only parent directory
+        Path readOnlyDir = temporaryFolder.resolve("readonly");
+        Files.createDirectory(readOnlyDir);
+        readOnlyDir.toFile().setReadOnly();
+
+        // Try to create a subdirectory in the read-only directory
+        Path invalidDir = readOnlyDir.resolve("data");
+
+        ExportCommand exportCommand = new ExportCommand("test", false, invalidDir);
+        Model model = new ModelManager();
+
+        String expectedErrorMsg = "Could not create directory";
+        String actualErrorMsg = "";
+
+        try {
+            exportCommand.execute(model);
+        } catch (Exception e) {
+            actualErrorMsg = e.getMessage();
+        } finally {
+            // Clean up: Reset directory permissions so it can be deleted
+            readOnlyDir.toFile().setWritable(true);
+        }
+
+        assertTrue(actualErrorMsg.contains(expectedErrorMsg));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -2,23 +2,67 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Paths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.student.Student;
+import seedu.address.testutil.StudentBuilder;
 
 public class ExportCommandTest {
 
+    @TempDir
+    public Path temporaryFolder;
+
+    private Path dataDir;
+    private Model model;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        dataDir = temporaryFolder.resolve("data");
+        Files.createDirectories(dataDir);
+        model = new ModelManager();
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        // Clean up any files created during tests
+        if (Files.exists(dataDir)) {
+            Files.walk(dataDir)
+                    .sorted((a, b) -> b.compareTo(a)) // Reverse order to delete files before directories
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            // Ignore deletion errors during cleanup
+                        }
+                    });
+        }
+    }
+
     @Test
     public void equals() {
-        ExportCommand command1 = new ExportCommand(Paths.get("file1.csv"));
-        ExportCommand command2 = new ExportCommand(Paths.get("file2.csv"));
+        ExportCommand command1 = new ExportCommand("file1", false, dataDir);
+        ExportCommand command2 = new ExportCommand("file2", false, dataDir);
+        ExportCommand command3 = new ExportCommand("file1", true, dataDir);
 
         // same object -> returns true
         assertTrue(command1.equals(command1));
 
         // same values -> returns true
-        ExportCommand command1Copy = new ExportCommand(Paths.get("file1.csv"));
+        ExportCommand command1Copy = new ExportCommand("file1", false, dataDir);
         assertTrue(command1.equals(command1Copy));
 
         // different types -> returns false
@@ -29,6 +73,9 @@ public class ExportCommandTest {
 
         // different file -> returns false
         assertFalse(command1.equals(command2));
+
+        // same file different force flag -> returns false
+        assertFalse(command1.equals(command3));
     }
 
     private void assertTrue(boolean equals) {
@@ -36,7 +83,76 @@ public class ExportCommandTest {
 
     @Test
     public void getCommandTypeMethod() {
-        ExportCommand exportCommand = new ExportCommand(Paths.get("file1.csv"));
-        assertEquals(exportCommand.getCommandType(), CommandType.EXPORTSTUDENT);
+        ExportCommand exportCommand = new ExportCommand("file1", false, dataDir);
+        assertEquals(CommandType.EXPORTSTUDENT, exportCommand.getCommandType());
+    }
+
+    @Test
+    public void execute_fileExists_throwsCommandException() throws IOException {
+        // Create a file that already exists
+        Path existingFile = dataDir.resolve("test.csv");
+        Files.createFile(existingFile);
+
+        ExportCommand exportCommand = new ExportCommand("test", false, dataDir);
+        assertThrows(CommandException.class, () -> exportCommand.execute(model));
+    }
+
+    @Test
+    public void execute_fileExistsWithForceFlag_success() throws IOException, CommandException {
+        // Add a sample student to the model
+        Student sampleStudent = new StudentBuilder().withName("John Doe")
+                .withPhone("12345678")
+                .withEmail("johndoe@example.com")
+                .withCourses("CS2103T").build();
+        model.addStudent(sampleStudent);
+
+        // Create a file that already exists
+        Path existingFile = dataDir.resolve("test.csv");
+        Files.createFile(existingFile);
+
+        ExportCommand exportCommand = new ExportCommand("test", true, dataDir);
+        CommandResult result = exportCommand.execute(model);
+
+        // Verify success message
+        assertTrue(result.getFeedbackToUser().contains("Exported"));
+
+        // Verify file contents
+        List<String> lines = Files.readAllLines(existingFile);
+        assertEquals(2, lines.size()); // Header + 1 student
+        assertEquals("Name,Phone,Email,Courses", lines.get(0));
+
+        String expectedLine = String.format("%s,%s,%s,%s",
+                sampleStudent.getName().fullName,
+                sampleStudent.getPhone().value,
+                sampleStudent.getEmail().value,
+                sampleStudent.getCourses().stream()
+                        .map(course -> course.toString())
+                        .collect(Collectors.joining(";")));
+        assertEquals(expectedLine, lines.get(1));
+    }
+
+    @Test
+    public void execute_normalExport_success() throws CommandException, IOException {
+        // Add a sample student to the model
+        Student sampleStudent = new StudentBuilder().withName("John Doe")
+                .withPhone("12345678")
+                .withEmail("johndoe@example.com")
+                .withCourses("CS2103T").build();
+        model.addStudent(sampleStudent);
+
+        ExportCommand exportCommand = new ExportCommand("test", false, dataDir);
+        CommandResult result = exportCommand.execute(model);
+
+        // Verify success message
+        assertTrue(result.getFeedbackToUser().contains("Exported"));
+
+        // Verify that the file was created
+        Path exportPath = dataDir.resolve("test.csv");
+        assertTrue(Files.exists(exportPath));
+
+        // Verify file contents
+        List<String> lines = Files.readAllLines(exportPath);
+        assertEquals(2, lines.size()); // Header + 1 student
+        assertEquals("Name,Phone,Email,Courses", lines.get(0));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONSULT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -197,9 +196,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_export() throws Exception {
-        String filePath = "data/export.csv";
+        String fileName = "export";
         ExportCommand command = (ExportCommand) parser.parseCommand(
-                ExportCommand.COMMAND_WORD + " " + filePath);
-        assertEquals(new ExportCommand(Paths.get(filePath)), command);
+                ExportCommand.COMMAND_WORD + " " + fileName);
+        assertEquals(new ExportCommand(fileName, false), command);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -84,4 +84,42 @@ public class ExportCommandParserTest {
         ExportCommand expectedHyphenCommand = new ExportCommand(filenameWithHyphen, false, dataDir);
         assertEquals(expectedHyphenCommand, parser.parse(filenameWithHyphen));
     }
+
+    @Test
+    public void parse_emptyFilename_throwsParseException() {
+        // When force flag is present but filename is empty
+        assertThrows(ParseException.class,
+                ExportCommandParser.MESSAGE_INVALID_FILENAME, () -> parser.parse("test.file"));
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("-f "));
+
+        // When force flag is present but only spaces after it
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("-f      "));
+    }
+
+    @Test
+    public void parse_forceWithoutFilename_throwsParseException() {
+        // Just "-f" without filename
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("-f"));
+
+        // "-f" with only spaces after it
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("-f    "));
+
+        // Multiple spaces before "-f"
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("    -f"));
+
+        // Multiple spaces before and after "-f"
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("    -f    "));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -4,26 +4,84 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Paths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ExportCommandParserTest {
-    private ExportCommandParser parser = new ExportCommandParser();
+    @TempDir
+    public Path temporaryFolder;
 
-    @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ExportCommand.MESSAGE_USAGE), () -> parser.parse("     "));
+    private ExportCommandParser parser;
+    private Path dataDir;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        parser = new ExportCommandParser();
+        dataDir = temporaryFolder.resolve("data");
+        Files.createDirectories(dataDir);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        // Clean up any files created during tests
+        if (Files.exists(dataDir)) {
+            Files.walk(dataDir)
+                    .sorted((a, b) -> b.compareTo(a))
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            // Ignore deletion errors during cleanup
+                        }
+                    });
+        }
     }
 
     @Test
-    public void parse_validArg_returnsExportCommand() throws ParseException {
-        String filePath = "data/export.csv";
-        ExportCommand expected = new ExportCommand(Paths.get(filePath));
-        assertEquals(expected, parser.parse(filePath));
+    public void parse_emptyArg_throwsParseException() {
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ExportCommand.MESSAGE_USAGE), () -> parser.parse("     "));
+    }
+
+    @Test
+    public void parse_invalidFilename_throwsParseException() {
+        // filename with period
+        assertThrows(ParseException.class,
+                ExportCommandParser.MESSAGE_INVALID_FILENAME, () -> parser.parse("test.file"));
+
+        // filename with slash
+        assertThrows(ParseException.class,
+                ExportCommandParser.MESSAGE_INVALID_FILENAME, () -> parser.parse("test/file"));
+
+        // filename with backslash
+        assertThrows(ParseException.class,
+                ExportCommandParser.MESSAGE_INVALID_FILENAME, () -> parser.parse("test\\file"));
+    }
+
+    @Test
+    public void parse_validArgs_returnsExportCommand() throws ParseException {
+        // normal filename
+        String filename = "testfile";
+        ExportCommand expectedCommand = new ExportCommand(filename, false, dataDir);
+        assertEquals(expectedCommand, parser.parse(filename));
+
+        // filename with force flag
+        ExportCommand expectedForceCommand = new ExportCommand(filename, true, dataDir);
+        assertEquals(expectedForceCommand, parser.parse("-f " + filename));
+
+        // filename with hyphen (not a force flag)
+        String filenameWithHyphen = "test-file";
+        ExportCommand expectedHyphenCommand = new ExportCommand(filenameWithHyphen, false, dataDir);
+        assertEquals(expectedHyphenCommand, parser.parse(filenameWithHyphen));
     }
 }


### PR DESCRIPTION
Fixes #133 

- Make export command check for unallowed characters such as slashes or periods. This ensures the export command will always generate a .csv file, where in the previous version, the user would have been able to generate a .png file for example.
- To make sure the user inputs a fileName instead of filePath, revert the export command to take a String instead of Path as a parameter. This ensures all user files are saved within the data folder, reducing chances of users accidentally saving .csv files in a random directory erroneously.
- Command now checks for the existence of a file with the same name as the user's input in the data directory. This prevents the user from accidentally overriding a previously saved file as TAHub will now warn the user.
- The user has the option to enter a "-f" flag to overwrite existing files with the same name.
- Updated and rewrote some tests to make them consistent with the updates.