### PR TITLE
Fix Consultation GUI not updating and prevent adding duplicate students

### DIFF
--- a/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
@@ -16,6 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.exceptions.DuplicateStudentException;
 
 /**
  * Adds students to a specific consultation.
@@ -31,7 +32,8 @@ public class AddToConsultCommand extends Command {
             + "[" + PREFIX_NAME + "NAME]...\n"
             + "Example: " + COMMAND_WORD + " 1 n/John Doe n/Harry Ng";
 
-    public static final String MESSAGE_ADD_TO_CONSULT_SUCCESS = "Added students to Consultation: %1$s";
+    public static final String MESSAGE_ADD_TO_CONSULT_SUCCESS = "Added students to the Consultation: %1$s";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION = "%s is already added to the consultation!";
 
     private final Index index;
     private final List<Name> studentNames;
@@ -58,16 +60,24 @@ public class AddToConsultCommand extends Command {
                 index.getOneBased()));
         }
 
-        Consultation consultationToEdit = lastShownList.get(index.getZeroBased());
+        Consultation targetConsultation = lastShownList.get(index.getZeroBased());
+        Consultation editedConsultation = new Consultation(targetConsultation);
 
         for (Name studentName : studentNames) {
             Student student = model.findStudentByName(studentName)
                     .orElseThrow(() -> new CommandException("Student not found: " + studentName));
-            consultationToEdit.addStudent(student);
+            try {
+                editedConsultation.addStudent(student);
+            } catch (DuplicateStudentException e) {
+                throw new CommandException(
+                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION, studentName));
+            }
         }
 
+        model.setConsult(targetConsultation, editedConsultation);
+
         return new CommandResult(
-            String.format(MESSAGE_ADD_TO_CONSULT_SUCCESS, Messages.format(consultationToEdit)),
+            String.format(MESSAGE_ADD_TO_CONSULT_SUCCESS, Messages.format(editedConsultation)),
             COMMAND_TYPE);
     }
 

--- a/src/main/java/seedu/address/logic/commands/consultation/RemoveFromConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/RemoveFromConsultCommand.java
@@ -66,21 +66,24 @@ public class RemoveFromConsultCommand extends Command {
             throw new CommandException("The consultation index provided is invalid.");
         }
 
-        Consultation consultationToEdit = lastShownList.get(consultIndex.getZeroBased());
+        Consultation targetConsultation = lastShownList.get(consultIndex.getZeroBased());
+        Consultation editedConsultation = new Consultation(targetConsultation);
 
         for (Name studentName : studentNames) {
             Student studentToRemove = model.findStudentByName(studentName)
                     .orElseThrow(() -> new CommandException("Student not found: " + studentName));
 
-            if (!consultationToEdit.hasStudent(studentToRemove)) {
+            if (!editedConsultation.hasStudent(studentToRemove)) {
                 throw new CommandException(MESSAGE_STUDENT_NOT_FOUND);
             }
 
-            consultationToEdit.removeStudent(studentToRemove);
+            editedConsultation.removeStudent(studentToRemove);
         }
 
+        model.setConsult(targetConsultation, editedConsultation);
+
         String successMessage = String.format(MESSAGE_REMOVE_FROM_CONSULT_SUCCESS,
-            consultationToEdit.getDate().getValue(), consultationToEdit.getTime().getValue());
+                editedConsultation.getDate().getValue(), editedConsultation.getTime().getValue());
 
         return new CommandResult(successMessage, COMMAND_TYPE);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 import java.util.Objects;
@@ -9,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.consultation.Consultation;
+import seedu.address.model.consultation.exceptions.ConsultationNotFoundException;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.UniqueStudentList;
 
@@ -124,6 +126,21 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedStudent);
 
         students.setStudent(target, editedStudent);
+    }
+
+    /**
+     * Replaces the given consultation {@code target} in the list with {@code editedConsult}.
+     * {@code target} must exist in TAHub.
+     */
+    public void setConsult(Consultation target, Consultation editedConsult) {
+        requireAllNonNull(target, editedConsult);
+
+        int index = consults.indexOf(target);
+        if (index == -1) {
+            throw new ConsultationNotFoundException();
+        }
+
+        consults.set(index, editedConsult);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -103,6 +103,15 @@ public interface Model {
      */
     void addConsult(Consultation consult);
 
+    /**
+     * Replaces the given Consultation {@code target} with {@code editedConsult}.
+     * {@code target} must exist in TAHub.
+     *
+     * @param target Target consultation to replace.
+     * @param editedConsult Consultation instance to replace the target with.
+     */
+    void setConsult(Consultation target, Consultation editedConsult);
+
     /** Returns an unmodifiable view of the filtered consultation list */
     ObservableList<Consultation> getFilteredConsultationList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -154,10 +154,15 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setConsult(Consultation target, Consultation newConsult) {
+        requireAllNonNull(target, newConsult);
+        addressBook.setConsult(target, newConsult);
+    }
+
+    @Override
     public boolean hasConsult(Consultation consult) {
         return addressBook.hasConsult(consult);
     }
-    //=========== Consultation Methods =============================================================
 
     @Override
     public Optional<Student> findStudentByName(Name name) {

--- a/src/main/java/seedu/address/model/consultation/Consultation.java
+++ b/src/main/java/seedu/address/model/consultation/Consultation.java
@@ -1,11 +1,14 @@
 package seedu.address.model.consultation;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 import seedu.address.model.student.Student;
+import seedu.address.model.student.exceptions.DuplicateStudentException;
 
 /**
  * Represents a Consultation in the system.
@@ -32,6 +35,20 @@ public class Consultation {
         this.time = time;
 
         this.students = students != null ? new ArrayList<>(students) : new ArrayList<>();
+    }
+
+    /**
+     * Constructs a copy of the given consultation.
+     * Creates new instances of date, time and the student list (not the students) to
+     * reduce the risk of accidental mutation.
+     *
+     * @param consultation The consultation to copy.
+     */
+    public Consultation(Consultation consultation) {
+        requireNonNull(consultation);
+        this.date = new Date(consultation.getDate().getValue());
+        this.time = new Time(consultation.getTime().getValue());
+        this.students = new ArrayList<>(consultation.getStudents());
     }
 
     /**
@@ -68,6 +85,9 @@ public class Consultation {
      * @param student The student to add.
      */
     public void addStudent(Student student) {
+        if (hasStudent(student)) {
+            throw new DuplicateStudentException();
+        }
         students.add(student);
     }
 

--- a/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
@@ -24,6 +24,8 @@ public class AddToConsultCommandTest {
     private final Index validIndex = Index.fromOneBased(1);
     private final ObservableList<Name> studentNames = FXCollections.observableArrayList(new Name("John Doe"),
         new Name("Harry Ng"));
+    private final ObservableList<Name> duplicateStudentNames = FXCollections.observableArrayList(new Name("John Doe"),
+            new Name("John Doe"));
 
     @Test
     public void execute_addStudentsToConsult_success() throws Exception {
@@ -55,6 +57,13 @@ public class AddToConsultCommandTest {
 
         AddToConsultCommand command = new AddToConsultCommand(validIndex, invalidStudentNames);
 
+        assertThrows(CommandException.class, () -> command.execute(modelStub));
+    }
+
+    @Test
+    public void execute_duplicateStudent_throwsCommandException() throws Exception {
+        ModelStubWithConsultation modelStub = new ModelStubWithConsultation();
+        AddToConsultCommand command = new AddToConsultCommand(validIndex, duplicateStudentNames);
         assertThrows(CommandException.class, () -> command.execute(modelStub));
     }
 

--- a/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.consultation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -59,14 +60,28 @@ public class AddToConsultCommandTest {
 
     // Model stub that contains a consultation and can return students by name
     private class ModelStubWithConsultation extends ModelStub {
+
         private final Consultation consultation = new Consultation(
                 new seedu.address.model.consultation.Date("2024-10-20"),
                 new seedu.address.model.consultation.Time("14:00"),
                 FXCollections.observableArrayList());
 
+        private ArrayList<Consultation> consults;
+
+        ModelStubWithConsultation() {
+            this.consults = new ArrayList<>();
+            this.consults.add(consultation);
+        }
+
+        @Override
+        public void setConsult(Consultation target, Consultation editedConsult) {
+            int index = this.consults.indexOf(target);
+            this.consults.set(index, editedConsult);
+        }
+
         @Override
         public ObservableList<Consultation> getFilteredConsultationList() {
-            return FXCollections.observableArrayList(consultation);
+            return FXCollections.observableArrayList(consults);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/consultation/RemoveFromConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/RemoveFromConsultCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -68,9 +69,22 @@ public class RemoveFromConsultCommandTest {
                         new StudentBuilder().withName("Alex Yeoh").build(),
                         new StudentBuilder().withName("Harry Ng").build()));
 
+        private ArrayList<Consultation> consults;
+
+        ModelStubWithConsultation() {
+            this.consults = new ArrayList<>();
+            this.consults.add(consultation);
+        }
+
+        @Override
+        public void setConsult(Consultation target, Consultation editedConsult) {
+            int index = this.consults.indexOf(target);
+            this.consults.set(index, editedConsult);
+        }
+
         @Override
         public ObservableList<Consultation> getFilteredConsultationList() {
-            return FXCollections.observableArrayList(consultation);
+            return FXCollections.observableArrayList(consults);
         }
 
         @Override

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_CS2103T;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalConsultations.CONSULT_1;
+import static seedu.address.testutil.TypicalConsultations.CONSULT_2;
 import static seedu.address.testutil.TypicalStudents.ALICE;
 
 import java.util.Arrays;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.consultation.Consultation;
+import seedu.address.model.consultation.exceptions.ConsultationNotFoundException;
 import seedu.address.model.student.Student;
 import seedu.address.model.student.exceptions.DuplicateStudentException;
 import seedu.address.testutil.ConsultationBuilder;
@@ -104,6 +107,29 @@ public class AddressBookTest {
         assertTrue(addressBook.hasConsult(copy));
     }
 
+    @Test
+    public void setConsult_allValidArguments_success() {
+        addressBook.addConsult(CONSULT_1);
+        assertTrue(addressBook.hasConsult(CONSULT_1));
+        assertFalse(addressBook.hasConsult(CONSULT_2));
+        addressBook.setConsult(CONSULT_1, CONSULT_2);
+        assertFalse(addressBook.hasConsult(CONSULT_1));
+        assertTrue(addressBook.hasConsult(CONSULT_2));
+    }
+
+    @Test
+    public void setConsult_nullArgument_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.setConsult(null, null));
+        assertThrows(NullPointerException.class, () -> addressBook.setConsult(null, CONSULT_1));
+        assertThrows(NullPointerException.class, () -> addressBook.setConsult(CONSULT_1, null));
+    }
+
+    @Test
+    public void setConsult_consultNotFound_throwsConsultationNotFoundException() {
+        // Ensure consult does not exist in the address book
+        assertFalse(addressBook.hasConsult(CONSULT_1));
+        assertThrows(ConsultationNotFoundException.class, () -> addressBook.setConsult(CONSULT_1, CONSULT_2));
+    }
 
     @Test
     public void getStudentList_modifyList_throwsUnsupportedOperationException() {

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -79,6 +79,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void setConsult(Consultation target, Consultation editedConsult) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Student> getFilteredStudentList() {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Closes #143. Closes #141.

Currently, the consultation list GUI does not update after performing `addtoconsult` and `removefromconsult`, hence any changes to the students in a consultation is not reflected on screen. Additionally, it is currently possible to add the same student to a consult multiple times.

Let's:
- implement the method `setConsult` in `Model` which replaces the old `Consultation` instance with a new one, thus updating the `ObservableList` so the GUI is able to observe the change, rather than modify the `Consultation` instance directly.
- implement a check to prevent a duplicate `Student` from being added to a `Consultation`.