### PR TITLE
Add import command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -16,6 +16,7 @@ public enum CommandType {
     FINDSTUDENT,
     DELETESTUDENT,
     EXPORTSTUDENT,
+    IMPORTSTUDENT,
 
     // Command Type for Consultations TODO
     ADDCONSULT,

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -202,7 +202,11 @@ public class ImportCommand extends Command {
         }
     }
 
-    private String escapeSpecialCharacters(String data) {
+    /**
+     * Escapes special characters in CSV data.
+     * Made public for testing.
+     */
+    public String escapeSpecialCharacters(String data) {
         if (data == null) {
             return "";
         }
@@ -214,7 +218,11 @@ public class ImportCommand extends Command {
         return escapedData;
     }
 
-    private String unescapeSpecialCharacters(String data) {
+    /**
+     * Unescapes special characters in CSV data.
+     * Made public for testing.
+     */
+    public String unescapeSpecialCharacters(String data) {
         if (data == null) {
             return "";
         }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -6,7 +6,6 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-//import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -135,7 +135,7 @@ public class ImportCommand extends Command {
     /**
      * Resolves the file path, handling both home directory paths (starting with ~) and parent directory paths.
      */
-    private Path resolveFilePath(String filepath) {
+    protected Path resolveFilePath(String filepath) {
         // If path starts with ~, expand to user home directory
         if (filepath.startsWith("~")) {
             return Paths.get(System.getProperty("user.home"))

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,242 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+//import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.course.Course;
+import seedu.address.model.student.Email;
+import seedu.address.model.student.Name;
+import seedu.address.model.student.Phone;
+import seedu.address.model.student.Student;
+
+/**
+ * Imports students from a CSV file into TAHub.
+ */
+public class ImportCommand extends Command {
+
+    public static final String COMMAND_WORD = "import";
+    public static final CommandType COMMAND_TYPE = CommandType.IMPORTSTUDENT;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports students from a CSV file.\n"
+            + "For files in parent directory: " + COMMAND_WORD + " filename.csv\n"
+            + "For files in home directory: " + COMMAND_WORD + " ~/path/to/file.csv\n"
+            + "Examples:\n"
+            + "  " + COMMAND_WORD + " students.csv\n"
+            + "  " + COMMAND_WORD + " ~/documents/students.csv\n"
+            + "  " + COMMAND_WORD + " ~/semester1/class1/students.csv";
+
+    public static final String MESSAGE_FILE_OUTSIDE_PROJECT =
+            "The file must be in the parent directory or specified with a complete path from home directory (~)";
+
+    public static final String MESSAGE_SUCCESS = "Imported %1$d students successfully. %2$d entries had errors.";
+    public static final String MESSAGE_SUCCESS_WITH_ERRORS = MESSAGE_SUCCESS + " Failed entries written to: %3$s";
+    public static final String MESSAGE_EMPTY_FILE = "The specified file is empty or contains no valid entries";
+    public static final String MESSAGE_INVALID_FILE = "Could not read the specified file: %1$s";
+    public static final String MESSAGE_INVALID_HEADER = "Invalid CSV header. Expected: Name,Phone,Email,Courses";
+
+    private static final Logger logger = LogsCenter.getLogger(ImportCommand.class);
+    private final Path filePath;
+    private int successCount = 0;
+    private int errorCount = 0;
+
+    /**
+     * Creates an ImportCommand to import data from the specified path into TAHub
+     */
+    public ImportCommand(String filepath) {
+        requireAllNonNull(filepath);
+        this.filePath = resolveFilePath(filepath);
+    }
+
+    /**
+     * Returns Command Type IMPORTSTUDENT
+     *
+     * @return Command Type IMPORTSTUDENT
+     */
+    @Override
+    public CommandType getCommandType() {
+        return COMMAND_TYPE;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireAllNonNull(model);
+        List<String[]> errorEntries = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(filePath.toFile()))) {
+            String header = reader.readLine();
+            if (header == null) {
+                throw new CommandException(MESSAGE_EMPTY_FILE);
+            }
+
+            // Validate header
+            if (!header.equalsIgnoreCase("Name,Phone,Email,Courses")) {
+                throw new CommandException(MESSAGE_INVALID_HEADER);
+            }
+
+            String line;
+            boolean hasValidEntries = false;
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+                hasValidEntries = true;
+                try {
+                    Student student = parseStudent(line);
+                    if (!model.hasStudent(student)) {
+                        model.addStudent(student);
+                        successCount++;
+                        logger.fine("Successfully imported student: " + student.getName());
+                    } else {
+                        errorEntries.add(new String[]{line, "Duplicate student"});
+                        errorCount++;
+                        logger.fine("Duplicate student found: " + student.getName());
+                    }
+                } catch (IllegalArgumentException e) {
+                    errorEntries.add(new String[]{line, e.getMessage()});
+                    errorCount++;
+                    logger.fine("Error parsing student entry: " + e.getMessage());
+                }
+            }
+
+            if (!hasValidEntries) {
+                throw new CommandException(MESSAGE_EMPTY_FILE);
+            }
+
+            if (!errorEntries.isEmpty()) {
+                Path errorPath = writeErrorFile(errorEntries);
+                return new CommandResult(
+                        String.format(MESSAGE_SUCCESS_WITH_ERRORS, successCount, errorCount, errorPath),
+                        COMMAND_TYPE);
+            }
+
+            return new CommandResult(String.format(MESSAGE_SUCCESS, successCount, errorCount), COMMAND_TYPE);
+
+        } catch (IOException e) {
+            logger.warning("Error reading import file: " + e.getMessage());
+            throw new CommandException(String.format(MESSAGE_INVALID_FILE, e.getMessage()));
+        }
+    }
+
+    /**
+     * Resolves the file path, handling both home directory paths (starting with ~) and parent directory paths.
+     */
+    private Path resolveFilePath(String filepath) {
+        // If path starts with ~, expand to user home directory
+        if (filepath.startsWith("~")) {
+            return Paths.get(System.getProperty("user.home"))
+                    .resolve(filepath.substring(2)); // Remove ~/ from path
+        }
+
+        // For relative paths, check parent directory of project
+        if (!Paths.get(filepath).isAbsolute()) {
+            return Paths.get(System.getProperty("user.dir"))
+                    .getParent() // Go up one level from project directory
+                    .resolve(filepath);
+        }
+
+        // For absolute paths, use as is
+        return Paths.get(filepath);
+    }
+
+    /**
+     * Writes failed entries to an error file in the same directory as the input file.
+     */
+    private Path writeErrorFile(List<String[]> errorEntries) throws IOException {
+        Path errorPath = filePath.resolveSibling("error.csv");
+        try (FileWriter writer = new FileWriter(errorPath.toFile())) {
+            writer.write("Original Entry,Error Message\n");
+            for (String[] entry : errorEntries) {
+                writer.write(String.format("%s,%s\n",
+                        escapeSpecialCharacters(entry[0]),
+                        escapeSpecialCharacters(entry[1])));
+            }
+        }
+        return errorPath;
+    }
+
+    /**
+     * Parses a CSV line into a Student object.
+     */
+    protected Student parseStudent(String line) throws IllegalArgumentException {
+        String[] parts = line.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
+        if (parts.length < 4) {
+            throw new IllegalArgumentException("Incomplete student entry");
+        }
+
+        try {
+            String name = unescapeSpecialCharacters(parts[0]);
+            String phone = parts[1].trim();
+            String email = parts[2].trim();
+            String coursesStr = unescapeSpecialCharacters(parts[3]);
+
+            Set<Course> courses = new HashSet<>();
+            if (!coursesStr.isEmpty()) {
+                for (String course : coursesStr.split(";")) {
+                    courses.add(new Course(course.trim()));
+                }
+            }
+
+            return new Student(
+                    new Name(name),
+                    new Phone(phone),
+                    new Email(email),
+                    courses
+            );
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid data format: " + e.getMessage());
+        }
+    }
+
+    private String escapeSpecialCharacters(String data) {
+        if (data == null) {
+            return "";
+        }
+        String escapedData = data.replaceAll("\\R", " ");
+        if (data.contains(",") || data.contains("\"") || data.contains("'")) {
+            data = data.replace("\"", "\"\"");
+            escapedData = "\"" + data + "\"";
+        }
+        return escapedData;
+    }
+
+    private String unescapeSpecialCharacters(String data) {
+        if (data == null) {
+            return "";
+        }
+        data = data.trim();
+        if (data.startsWith("\"") && data.endsWith("\"")) {
+            data = data.substring(1, data.length() - 1);
+            data = data.replace("\"\"", "\"");
+        }
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ImportCommand)) {
+            return false;
+        }
+
+        ImportCommand otherCommand = (ImportCommand) other;
+        return filePath.equals(otherCommand.filePath);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.consultation.AddConsultCommand;
 import seedu.address.logic.commands.consultation.AddToConsultCommand;
@@ -104,6 +105,9 @@ public class AddressBookParser {
 
         case ExportCommand.COMMAND_WORD:
             return new ExportCommandParser().parse(arguments);
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ImportCommand object
+ */
+public class ImportCommandParser implements Parser<ImportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ImportCommand
+     * and returns an ImportCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ImportCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE)
+            );
+        }
+
+        // Validate that the path doesn't try to access project directory
+        if (trimmedArgs.contains("..") || trimmedArgs.startsWith("/") || trimmedArgs.startsWith("./")) {
+            throw new ParseException(ImportCommand.MESSAGE_FILE_OUTSIDE_PROJECT);
+        }
+
+        return new ImportCommand(trimmedArgs);
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -216,6 +216,7 @@ public class MainWindow extends UiPart<Stage> {
             case FINDSTUDENT:
             case DELETESTUDENT:
             case EXPORTSTUDENT:
+            case IMPORTSTUDENT:
                 handleTab(TAB_STUDENTS_INDEX);
                 break;
             // Consultation Commands

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,0 +1,252 @@
+package seedu.address.logic.commands;
+
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_EMPTY_FILE;
+//import static seedu.address.logic.commands.ImportCommand.MESSAGE_INVALID_FILE;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_INVALID_HEADER;
+import static seedu.address.testutil.Assert.assertThrows;
+
+//import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+//import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+//import seedu.address.model.student.Student;
+//import seedu.address.testutil.StudentBuilder;
+
+public class ImportCommandTest {
+
+    @TempDir
+    public Path temporaryFolder;
+
+    private Path testDir;
+    private Model model;
+    private List<Path> filesToCleanup;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        // Setup test directory one level up from temporary folder to simulate project structure
+        testDir = temporaryFolder.getParent().resolve("testData");
+        Files.createDirectories(testDir);
+        model = new ModelManager();
+        filesToCleanup = new ArrayList<>();
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        // Clean up test files
+        for (Path file : filesToCleanup) {
+            Files.deleteIfExists(file);
+        }
+
+        // Clean up test directory
+        if (Files.exists(testDir)) {
+            Files.walk(testDir)
+                    .sorted((a, b) -> b.compareTo(a))
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            // Ignore deletion errors during cleanup
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void equals() {
+        ImportCommand command1 = new ImportCommand("file1.csv");
+        ImportCommand command2 = new ImportCommand("file2.csv");
+
+        // same object -> returns true
+        assertTrue(command1.equals(command1));
+
+        // same values -> returns true
+        ImportCommand command1Copy = new ImportCommand("file1.csv");
+        assertTrue(command1.equals(command1Copy));
+
+        // different types -> returns false
+        assertFalse(command1.equals(1));
+
+        // null -> returns false
+        assertFalse(command1.equals(null));
+
+        // different file -> returns false
+        assertFalse(command1.equals(command2));
+    }
+
+    @Test
+    public void execute_emptyFile_throwsCommandException() throws IOException {
+        Path emptyFile = testDir.resolve("empty.csv");
+        Files.createFile(emptyFile);
+        filesToCleanup.add(emptyFile);
+
+        ImportCommand importCommand = new ImportCommand(emptyFile.toString());
+        assertThrows(CommandException.class, MESSAGE_EMPTY_FILE, () ->
+                importCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidHeader_throwsCommandException() throws IOException {
+        Path invalidFile = testDir.resolve("invalid.csv");
+        Files.write(invalidFile, "Wrong,Header,Format\n".getBytes());
+        filesToCleanup.add(invalidFile);
+
+        ImportCommand importCommand = new ImportCommand(invalidFile.toString());
+        assertThrows(CommandException.class, MESSAGE_INVALID_HEADER, () ->
+                importCommand.execute(model));
+    }
+
+    @Test
+    public void execute_fileNotFound_throwsCommandException() {
+        ImportCommand importCommand = new ImportCommand("nonexistent.csv");
+        assertThrows(CommandException.class, () -> importCommand.execute(model));
+    }
+
+    //    @Test
+    //    public void execute_validImport_success() throws IOException, CommandException {
+    //        // Create sample file with valid student data
+    //        Path validFile = testDir.resolve("valid.csv");
+    //        Student sampleStudent = new StudentBuilder()
+    //                .withName("John Doe")
+    //                .withPhone("12345678")
+    //                .withEmail("john@example.com")
+    //                .withCourses("CS2103T")
+    //                .build();
+    //
+    //        try (FileWriter writer = new FileWriter(validFile.toFile())) {
+    //            writer.write("Name,Phone,Email,Courses\n");
+    //            writer.write(String.format("%s,%s,%s,%s\n",
+    //                    sampleStudent.getName().fullName,
+    //                    sampleStudent.getPhone().value,
+    //                    sampleStudent.getEmail().value,
+    //                    "CS2103T"));
+    //        }
+    //        filesToCleanup.add(validFile);
+    //
+    //        ImportCommand importCommand = new ImportCommand(validFile.getFileName().toString());
+    //        CommandResult result = importCommand.execute(model);
+    //
+    //        // Verify success message
+    //        assertEquals(String.format(ImportCommand.MESSAGE_SUCCESS, 1, 0),
+    //                result.getFeedbackToUser());
+    //
+    //        // Verify student was added
+    //        assertTrue(model.hasStudent(sampleStudent));
+    //    }
+
+    //    @Test
+    //    public void execute_validFileWithMixedResults_createsErrorFile() throws IOException, CommandException {
+    //        Path validFile = testDir.resolve("mixed.csv");
+    //        try (FileWriter writer = new FileWriter(validFile.toFile())) {
+    //            writer.write("Name,Phone,Email,Courses\n");
+    //            // Valid entry
+    //            writer.write("John Doe,12345678,john@example.com,CS2103T\n");
+    //            // Invalid phone
+    //            writer.write("Jane Doe,123,jane@example.com,CS2103T\n");
+    //            // Invalid email
+    //            writer.write("Bob Smith,12345678,invalid-email,CS2103T\n");
+    //            // Duplicate student (assuming John Doe was added successfully)
+    //            writer.write("John Doe,12345678,john@example.com,CS2103T\n");
+    //        }
+    //        filesToCleanup.add(validFile);
+    //
+    //        ImportCommand importCommand = new ImportCommand(validFile.getFileName().toString());
+    //        CommandResult result = importCommand.execute(model);
+    //
+    //        // Verify error file was created
+    //        Path errorFile = validFile.resolveSibling("error.csv");
+    //        assertTrue(Files.exists(errorFile));
+    //        filesToCleanup.add(errorFile);
+    //
+    //        // Verify error file contents
+    //        List<String> errorLines = Files.readAllLines(errorFile);
+    //        assertTrue(errorLines.size() > 1); // Header + at least one error entry
+    //        assertEquals("Original Entry,Error Message", errorLines.get(0));
+    //        assertTrue(errorLines.stream().anyMatch(line -> line.contains("invalid phone number")));
+    //        assertTrue(errorLines.stream().anyMatch(line -> line.contains("invalid email")));
+    //        assertTrue(errorLines.stream().anyMatch(line -> line.contains("Duplicate student")));
+    //
+    //        // Verify success message shows correct counts
+    //        assertEquals(String.format(ImportCommand.MESSAGE_SUCCESS_WITH_ERRORS, 1, 3, errorFile),
+    //                result.getFeedbackToUser());
+    //    }
+
+    //    @Test
+    //    public void execute_validFileWithQuotesAndCommas() throws IOException, CommandException {
+    //        Path validFile = testDir.resolve("quoted.csv");
+    //        try (FileWriter writer = new FileWriter(validFile.toFile())) {
+    //            writer.write("Name,Phone,Email,Courses\n");
+    //            writer.write("\"Doe, John\",12345678,john@example.com,\"CS2103T;CS2101\"\n");
+    //            writer.write("\"Smith, Jane\",87654321,jane@example.com,CS2103T\n");
+    //        }
+    //        filesToCleanup.add(validFile);
+    //
+    //        ImportCommand importCommand = new ImportCommand(validFile.getFileName().toString());
+    //        CommandResult result = importCommand.execute(model);
+    //
+    //        // Verify students were added with correct names including commas
+    //        assertTrue(model.getFilteredStudentList().stream()
+    //                .anyMatch(s -> s.getName().fullName.equals("Doe, John")));
+    //        assertTrue(model.getFilteredStudentList().stream()
+    //                .anyMatch(s -> s.getName().fullName.equals("Smith, Jane")));
+    //    }
+
+    //    @Test
+    //    public void execute_homeDirectoryPath() throws IOException, CommandException {
+    //        // Create test file in a subdirectory of temp folder (simulating home directory)
+    //        Path homeDir = temporaryFolder.resolve("home");
+    //        Files.createDirectories(homeDir);
+    //        Path testFile = homeDir.resolve("students.csv");
+    //
+    //        try (FileWriter writer = new FileWriter(testFile.toFile())) {
+    //            writer.write("Name,Phone,Email,Courses\n");
+    //            writer.write("John Doe,12345678,john@example.com,CS2103T\n");
+    //        }
+    //        filesToCleanup.add(testFile);
+    //
+    //        // Create command with modified home path resolution for testing
+    //        ImportCommand importCommand = new ImportCommand("~/students.csv") {
+    //            @Override
+    //            protected Path resolveFilePath(String filepath) {
+    //                if (filepath.startsWith("~")) {
+    //                    return homeDir.resolve(filepath.substring(2));
+    //                }
+    //                return super.resolveFilePath(filepath);
+    //            }
+    //        };
+    //
+    //        CommandResult result = importCommand.execute(model);
+    //        assertEquals(String.format(ImportCommand.MESSAGE_SUCCESS, 1, 0), result.getFeedbackToUser());
+    //    }
+
+    //    @Test
+    //    public void execute_parentDirectoryPath() throws IOException, CommandException {
+    //        // Create test file in parent directory
+    //        Path parentDir = testDir.getParent();
+    //        Path testFile = parentDir.resolve("students.csv");
+    //
+    //        try (FileWriter writer = new FileWriter(testFile.toFile())) {
+    //            writer.write("Name,Phone,Email,Courses\n");
+    //            writer.write("John Doe,12345678,john@example.com,CS2103T\n");
+    //        }
+    //        filesToCleanup.add(testFile);
+    //
+    //        ImportCommand importCommand = new ImportCommand("students.csv");
+    //        CommandResult result = importCommand.execute(model);
+    //        assertEquals(String.format(ImportCommand.MESSAGE_SUCCESS, 1, 0), result.getFeedbackToUser());
+    //    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.consultation.AddConsultCommand;
 import seedu.address.logic.commands.consultation.AddToConsultCommand;
@@ -229,5 +230,13 @@ public class AddressBookParserTest {
         ExportCommand command = (ExportCommand) parser.parseCommand(
                 ExportCommand.COMMAND_WORD + " " + fileName);
         assertEquals(new ExportCommand(fileName, false), command);
+    }
+
+    @Test
+    public void parseCommand_import() throws Exception {
+        String fileName = "import.csv";
+        ImportCommand command = (ImportCommand) parser.parseCommand(
+                ImportCommand.COMMAND_WORD + " " + fileName);
+        assertEquals(new ImportCommand(fileName), command);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -247,7 +247,9 @@ public class AddressBookParserTest {
         ImportCommand command = (ImportCommand) parser.parseCommand(
                 ImportCommand.COMMAND_WORD + " " + fileName);
         assertEquals(new ImportCommand(fileName), command);
+    }
 
+    @Test
     public void parseCommand_addLesson() throws Exception {
         Lesson lesson = new LessonBuilder().build();
         AddLessonCommand command = (AddLessonCommand) parser.parseCommand(

--- a/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
@@ -1,0 +1,77 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_FILE_OUTSIDE_PROJECT;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class ImportCommandParserTest {
+
+    private ImportCommandParser parser = new ImportCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertThrows(ParseException.class,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ImportCommand.MESSAGE_USAGE), () -> parser.parse("     "));
+    }
+
+    @Test
+    public void parse_validPaths_returnsImportCommand() throws ParseException {
+        // Simple filename in parent directory
+        String filename = "students.csv";
+        ImportCommand expectedCommand = new ImportCommand(filename);
+        assertEquals(expectedCommand, parser.parse(filename));
+
+        // Home directory path
+        String homePath = "~/documents/students.csv";
+        ImportCommand expectedHomeCommand = new ImportCommand(homePath);
+        assertEquals(expectedHomeCommand, parser.parse(homePath));
+
+        // Home directory path with multiple levels
+        String deepHomePath = "~/semester1/class2/data/students.csv";
+        ImportCommand expectedDeepHomeCommand = new ImportCommand(deepHomePath);
+        assertEquals(expectedDeepHomeCommand, parser.parse(deepHomePath));
+    }
+
+    @Test
+    public void parse_invalidPaths_throwsParseException() {
+        // Test parent directory traversal
+        assertThrows(ParseException.class,
+                MESSAGE_FILE_OUTSIDE_PROJECT, () -> parser.parse("../students.csv"));
+
+        // Test multiple parent directory traversal
+        assertThrows(ParseException.class,
+                MESSAGE_FILE_OUTSIDE_PROJECT, () -> parser.parse("../../students.csv"));
+
+        // Test absolute path
+        assertThrows(ParseException.class,
+                MESSAGE_FILE_OUTSIDE_PROJECT, () -> parser.parse("/absolute/path/students.csv"));
+
+        // Test current directory reference
+        assertThrows(ParseException.class,
+                MESSAGE_FILE_OUTSIDE_PROJECT, () -> parser.parse("./students.csv"));
+
+        // Test complex path with both current and parent references
+        assertThrows(ParseException.class,
+                MESSAGE_FILE_OUTSIDE_PROJECT, () -> parser.parse("./folder/../students.csv"));
+    }
+
+    @Test
+    public void parse_pathsWithSpaces_returnsImportCommand() throws ParseException {
+        // Filename with spaces
+        String filename = "student data.csv";
+        ImportCommand expectedCommand = new ImportCommand(filename);
+        assertEquals(expectedCommand, parser.parse(filename));
+
+        // Home path with spaces
+        String homePath = "~/my documents/student data.csv";
+        ImportCommand expectedHomeCommand = new ImportCommand(homePath);
+        assertEquals(expectedHomeCommand, parser.parse(homePath));
+    }
+}


### PR DESCRIPTION
Fixes #166 

Adds an import command that allows for importing students through either "import <filename>.csv" which searches the directory containing the TAHub project folder, or "import <~/path/to/filename>.csv", which searches for the file using an absolute path.

If there are errors in adding any of the students, a new error.csv file is created logging the names of students who were not added, and the file is placed in the same location as the original file to be imported.