### PR TITLE
Add student attendance to Lesson

### DIFF
--- a/src/main/java/seedu/address/logic/parser/lesson/AddLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/lesson/AddLessonCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
 import java.util.List;
+import java.util.Map;
 
 import seedu.address.logic.commands.lesson.AddLessonCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -39,7 +40,7 @@ public class AddLessonCommandParser implements Parser<AddLessonCommand> {
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Time time = ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get());
 
-        Lesson lesson = new Lesson(date, time, List.of());
+        Lesson lesson = new Lesson(date, time, List.of(), Map.of());
 
         return new AddLessonCommand(lesson);
     }

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -1,7 +1,7 @@
 package seedu.address.model.lesson;
 
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -1,9 +1,6 @@
 package seedu.address.model.lesson;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import seedu.address.model.consultation.Date;
 import seedu.address.model.consultation.Time;
@@ -18,6 +15,7 @@ public class Lesson {
     private final Date date;
     private final Time time;
     private final List<Student> students;
+    private final HashMap<Student, Boolean> attendanceMap;
 
     /**
      * Constructs a {@code Lesson}.
@@ -26,13 +24,17 @@ public class Lesson {
      * @param time The time of the lesson.
      * @param students A list of students attending the lesson.
      *                 This list can be empty but must not be null.
-     * @throws NullPointerException if {@code date} or {@code time} is null.
+     * @throws NullPointerException if any of the arguments are null.
      */
     public Lesson(Date date, Time time, List<Student> students) {
-        requireAllNonNull(date, time);
+        requireAllNonNull(date, time, students);
         this.date = date;
         this.time = time;
-        this.students = students != null ? new ArrayList<>(students) : new ArrayList<>();
+        this.students = new ArrayList<>();
+        this.students.addAll(students);
+        // fill out the default attendance as false
+        this.attendanceMap = new HashMap<>();
+        this.students.forEach(student -> this.attendanceMap.put(student, false));
     }
 
     /**
@@ -79,6 +81,26 @@ public class Lesson {
      */
     public void removeStudent(Student student) {
         students.remove(student);
+    }
+
+    /**
+     * Sets the attendance of the student to the specified value.
+     *
+     * @param student The student to mark.
+     * @param isAttending True if the student is attending this lesson, false otherwise.
+     */
+    public void setAttendance(Student student, boolean isAttending) {
+        this.attendanceMap.put(student, isAttending);
+    }
+
+    /**
+     * Returns true if this student is marked as having attended this lesson.
+     *
+     * @param student The student to check.
+     * @return True if the student is marked as having attended the lesson.
+     */
+    public boolean getAttendance(Student student) {
+        return this.attendanceMap.get(student);
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javafx.util.Pair;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.consultation.Date;
@@ -36,7 +38,7 @@ class JsonAdaptedLesson {
     public JsonAdaptedLesson(@JsonProperty("date") String date,
             @JsonProperty("time") String time,
             @JsonProperty("students") List<JsonAdaptedStudent> students,
-            @JsonProperty("attendanceMap") Map<JsonAdaptedStudent, Boolean> attendanceMap) {
+            @JsonProperty("attendanceMap") Set<Pair<JsonAdaptedStudent, Boolean>> attendanceMap) {
         this.date = date;
         this.time = time;
         this.students = new ArrayList<>();
@@ -46,7 +48,7 @@ class JsonAdaptedLesson {
             this.students.addAll(students);
         }
         if (attendanceMap != null) {
-            this.attendanceMap.putAll(attendanceMap);
+            attendanceMap.forEach(pair -> this.attendanceMap.put(pair.getKey(), pair.getValue()));
         }
 
     }
@@ -65,6 +67,7 @@ class JsonAdaptedLesson {
             boolean attendance = source.getAttendance(student);
             students.add(jsonAdaptedStudent);
             attendanceMap.put(jsonAdaptedStudent, attendance);
+            // attendanceMap.add(new Pair<>(jsonAdaptedStudent, attendance));
         }
     }
 
@@ -125,7 +128,6 @@ class JsonAdaptedLesson {
         final List<Student> modelStudents = new ArrayList<>();
         final HashMap<Student, Boolean> modelAttendanceMap = new HashMap<>();
 
-        // Update student list and maps in the same loop for efficiency
         for (JsonAdaptedStudent student : students) {
             Student modelStudent = student.toModelType();
 
@@ -136,8 +138,8 @@ class JsonAdaptedLesson {
             }
 
             modelStudents.add(modelStudent);
-            boolean attendance = attendanceMap.get(student);
-            modelAttendanceMap.put(modelStudent, attendance);
+            // if the student is not found in attendanceMap, defaults to no attendance
+            modelAttendanceMap.put(modelStudent, attendanceMap.getOrDefault(student, false));
         }
 
         return new Lesson(modelDate, modelTime, modelStudents, modelAttendanceMap);

--- a/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
@@ -154,7 +154,7 @@ class JsonAdaptedLesson {
     private boolean getAttendance(JsonAdaptedStudent jsonStudent) {
         for (Pair<JsonAdaptedStudent, Boolean> pair : attendanceList) {
             if (pair.getKey().equals(jsonStudent)) {
-                return pair.getVal();
+                return pair.getValue();
             }
         }
         return false; // the default attendance is false if data is not found

--- a/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLesson.java
@@ -3,13 +3,10 @@ package seedu.address.storage;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javafx.util.Pair;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.consultation.Date;
@@ -29,7 +26,7 @@ class JsonAdaptedLesson {
     private final String date;
     private final String time;
     private final List<JsonAdaptedStudent> students;
-    private final Map<JsonAdaptedStudent, Boolean> attendanceMap;
+    private final List<Boolean> attendanceMap;
 
     /**
      * Constructs a {@code JsonAdaptedLesson} with the given lesson details.
@@ -38,17 +35,17 @@ class JsonAdaptedLesson {
     public JsonAdaptedLesson(@JsonProperty("date") String date,
             @JsonProperty("time") String time,
             @JsonProperty("students") List<JsonAdaptedStudent> students,
-            @JsonProperty("attendanceMap") Set<Pair<JsonAdaptedStudent, Boolean>> attendanceMap) {
+            @JsonProperty("attendanceMap") List<Boolean> attendanceMap) {
         this.date = date;
         this.time = time;
         this.students = new ArrayList<>();
-        this.attendanceMap = new HashMap<>();
+        this.attendanceMap = new ArrayList<>();
         // Null check required because the JsonCreator constructor may be called with null if the fields do not exist
         if (students != null) {
             this.students.addAll(students);
         }
         if (attendanceMap != null) {
-            attendanceMap.forEach(pair -> this.attendanceMap.put(pair.getKey(), pair.getValue()));
+            this.attendanceMap.addAll(attendanceMap);
         }
 
     }
@@ -60,14 +57,13 @@ class JsonAdaptedLesson {
         date = source.getDate().toString();
         time = source.getTime().toString();
         students = new ArrayList<>();
-        attendanceMap = new HashMap<>();
+        attendanceMap = new ArrayList<>();
 
         for (Student student : source.getStudents()) {
             JsonAdaptedStudent jsonAdaptedStudent = new JsonAdaptedStudent(student);
             boolean attendance = source.getAttendance(student);
             students.add(jsonAdaptedStudent);
-            attendanceMap.put(jsonAdaptedStudent, attendance);
-            // attendanceMap.add(new Pair<>(jsonAdaptedStudent, attendance));
+            attendanceMap.add(attendance);
         }
     }
 
@@ -128,6 +124,7 @@ class JsonAdaptedLesson {
         final List<Student> modelStudents = new ArrayList<>();
         final HashMap<Student, Boolean> modelAttendanceMap = new HashMap<>();
 
+        int i = 0;
         for (JsonAdaptedStudent student : students) {
             Student modelStudent = student.toModelType();
 
@@ -139,7 +136,11 @@ class JsonAdaptedLesson {
 
             modelStudents.add(modelStudent);
             // if the student is not found in attendanceMap, defaults to no attendance
-            modelAttendanceMap.put(modelStudent, attendanceMap.getOrDefault(student, false));
+            if (i < attendanceMap.size()) {
+                modelAttendanceMap.put(modelStudent, attendanceMap.get(i++));
+            } else {
+                modelAttendanceMap.put(modelStudent, false);
+            }
         }
 
         return new Lesson(modelDate, modelTime, modelStudents, modelAttendanceMap);

--- a/src/main/java/seedu/address/storage/Pair.java
+++ b/src/main/java/seedu/address/storage/Pair.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * This class encapsulates a generic Pair structure because JavaFX's Pair class throws an InaccessibleObjectException
@@ -28,7 +29,26 @@ public class Pair <K, V> implements Serializable {
         return key;
     }
 
-    public V getVal() {
+    public V getValue() {
         return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Pair<?, ?> otherPair)) {
+            return false;
+        }
+
+        return key.equals(otherPair.key)
+                && value.equals(otherPair.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
     }
 }

--- a/src/main/java/seedu/address/storage/Pair.java
+++ b/src/main/java/seedu/address/storage/Pair.java
@@ -1,0 +1,34 @@
+package seedu.address.storage;
+
+import java.io.Serializable;
+
+/**
+ * This class encapsulates a generic Pair structure because JavaFX's Pair class throws an InaccessibleObjectException
+ * on GitHub for an unknown reason.
+ *
+ * @param <K> Type of the key.
+ * @param <V> Type of the value.
+ */
+public class Pair <K, V> implements Serializable {
+    private final K key;
+    private final V value;
+
+    /**
+     * Creates a new Pair instance with the given key and value.
+     *
+     * @param key The key.
+     * @param value The value.
+     */
+    public Pair(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public V getVal() {
+        return value;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/lesson/AddToLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/lesson/AddToLessonCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -73,7 +74,8 @@ public class AddToLessonCommandTest {
         private final Lesson lesson = new Lesson(
                 new seedu.address.model.consultation.Date("2024-10-20"),
                 new seedu.address.model.consultation.Time("14:00"),
-                FXCollections.observableArrayList());
+                FXCollections.observableArrayList(),
+                Map.of());
 
         private ArrayList<Lesson> lessons;
 

--- a/src/test/java/seedu/address/logic/commands/lesson/RemoveFromLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/lesson/RemoveFromLessonCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,12 +62,14 @@ public class RemoveFromLessonCommandTest {
 
     // Model stub that contains a lesson and can return students by name
     private class ModelStubWithLesson extends ModelStub {
+
+        private final Student student1 = new StudentBuilder().withName("Alex Yeoh").build();
+        private final Student student2 = new StudentBuilder().withName("Harry Ng").build();
         private final Lesson lesson = new Lesson(
                 new seedu.address.model.consultation.Date("2024-10-20"),
                 new seedu.address.model.consultation.Time("14:00"),
-                FXCollections.observableArrayList(
-                        new StudentBuilder().withName("Alex Yeoh").build(),
-                        new StudentBuilder().withName("Harry Ng").build()));
+                FXCollections.observableArrayList(student1, student2),
+                Map.of(student1, true, student2, false));
 
         private ArrayList<Lesson> lessons;
 

--- a/src/test/java/seedu/address/logic/parser/lesson/AddLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/lesson/AddLessonCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,7 @@ public class AddLessonCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         AddLessonCommand expectedCommand = new AddLessonCommand(
-                new Lesson(new Date("2024-10-20"), new Time("14:00"), List.of()));
+                new Lesson(new Date("2024-10-20"), new Time("14:00"), List.of(), Map.of()));
 
         assertParseSuccess(parser, " d/2024-10-20 t/14:00", expectedCommand);
     }

--- a/src/test/java/seedu/address/model/lesson/LessonTest.java
+++ b/src/test/java/seedu/address/model/lesson/LessonTest.java
@@ -1,6 +1,7 @@
 package seedu.address.model.lesson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.consultation.Date;
 import seedu.address.model.consultation.Time;
 import seedu.address.model.student.Student;
+import seedu.address.model.student.exceptions.StudentNotFoundException;
 import seedu.address.testutil.StudentBuilder;
 
 public class LessonTest {
@@ -46,6 +48,12 @@ public class LessonTest {
     }
 
     @Test
+    public void constructor_studentNotInAttendanceMap_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> new Lesson(date, time,
+                List.of(student1), Collections.emptyMap()));
+    }
+
+    @Test
     public void getDate_success() {
         Lesson lesson = new Lesson(date, time, Collections.emptyList(), Collections.emptyMap());
         assertEquals(date, lesson.getDate());
@@ -66,6 +74,14 @@ public class LessonTest {
     }
 
     @Test
+    public void getStudents_modifyAttendanceMap_throwsUnsupportedOperationException() {
+        Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
+        Map<Student, Boolean> attendanceMap = lesson.getAttendanceMap();
+        assertThrows(UnsupportedOperationException.class, () -> attendanceMap.put(student1, true));
+    }
+
+    @Test
     public void addStudent_success() {
         Lesson lesson = new Lesson(date, time, Collections.emptyList(), Collections.emptyMap());
         lesson.addStudent(student1);
@@ -73,11 +89,57 @@ public class LessonTest {
     }
 
     @Test
+    public void addStudent_alsoAddToAttendanceMap() {
+        Lesson lesson = new Lesson(date, time, Collections.emptyList(), Collections.emptyMap());
+        lesson.addStudent(student1);
+        assertTrue(lesson.getAttendanceMap().containsKey(student1));
+    }
+
+    @Test
     public void removeStudent_success() {
         Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2),
                 Map.of(student1, false, student2, false));
         lesson.removeStudent(student1);
-        assertTrue(!lesson.getStudents().contains(student1));
+        assertFalse(lesson.getStudents().contains(student1));
+    }
+
+    @Test
+    public void removeStudent_alsoRemoveFromAttendanceMap() {
+        Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
+        lesson.removeStudent(student1);
+        assertFalse(lesson.getAttendanceMap().containsKey(student1));
+    }
+
+    @Test
+    public void getAttendance_studentExists_success() {
+        boolean attendance = true;
+        Lesson lesson = new Lesson(date, time, List.of(student1), Map.of(student1, attendance));
+        assertEquals(lesson.getAttendance(student1), attendance);
+    }
+
+    @Test
+    public void getAttendance_studentDoesNotExist_throwsStudentNotFoundException() {
+        boolean attendance = true;
+        Lesson lesson = new Lesson(date, time, List.of(student1), Map.of(student1, attendance));
+        assertFalse(lesson.getStudents().contains(student2));
+        assertThrows(StudentNotFoundException.class, () -> lesson.getAttendance(student2));
+    }
+
+    @Test
+    public void setAttendance_studentExists_success() {
+        Lesson lesson = new Lesson(date, time, List.of(student1), Map.of(student1, false));
+        boolean newAttendance = true;
+        lesson.setAttendance(student1, newAttendance);
+        assertEquals(lesson.getAttendance(student1), newAttendance);
+    }
+
+    @Test
+    public void setAttendance_studentDoesNotExist_throwsStudentNotFoundException() {
+        Lesson lesson = new Lesson(date, time, List.of(student1), Map.of(student1, false));
+        boolean newAttendance = true;
+        assertFalse(lesson.getStudents().contains(student2));
+        assertThrows(StudentNotFoundException.class, () -> lesson.setAttendance(student2, newAttendance));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/lesson/LessonTest.java
+++ b/src/test/java/seedu/address/model/lesson/LessonTest.java
@@ -176,4 +176,14 @@ public class LessonTest {
                 Map.of(student1, false));
         assertNotEquals(lesson1.hashCode(), lesson2.hashCode());
     }
+
+    @Test
+    public void toString_returnsExpectedString() {
+        List<Student> students = List.of(student1);
+        Map<Student, Boolean> attendanceMap = Map.of(student1, true);
+        Lesson lesson = new Lesson(date, time, students, attendanceMap);
+        String expected = String.format("Lesson[date=%s, time=%s, students=%s, attendanceMap=%s]",
+                date, time, students, attendanceMap);
+        assertEquals(lesson.toString(), expected);
+    }
 }

--- a/src/test/java/seedu/address/model/lesson/LessonTest.java
+++ b/src/test/java/seedu/address/model/lesson/LessonTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,72 +35,83 @@ public class LessonTest {
 
     @Test
     public void constructor_nullDate_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Lesson(null, time, Collections.emptyList()));
+        assertThrows(NullPointerException.class, () -> new Lesson(null, time,
+                Collections.emptyList(), Collections.emptyMap()));
     }
 
     @Test
     public void constructor_nullTime_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Lesson(date, null, Collections.emptyList()));
+        assertThrows(NullPointerException.class, () -> new Lesson(date, null,
+                Collections.emptyList(), Collections.emptyMap()));
     }
 
     @Test
     public void getDate_success() {
-        Lesson lesson = new Lesson(date, time, Collections.emptyList());
+        Lesson lesson = new Lesson(date, time, Collections.emptyList(), Collections.emptyMap());
         assertEquals(date, lesson.getDate());
     }
 
     @Test
     public void getTime_success() {
-        Lesson lesson = new Lesson(date, time, Collections.emptyList());
+        Lesson lesson = new Lesson(date, time, Collections.emptyList(), Collections.emptyMap());
         assertEquals(time, lesson.getTime());
     }
 
     @Test
     public void getStudents_modifyList_throwsUnsupportedOperationException() {
-        Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2));
+        Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
         List<Student> students = lesson.getStudents();
         assertThrows(UnsupportedOperationException.class, () -> students.add(new StudentBuilder().build()));
     }
 
     @Test
     public void addStudent_success() {
-        Lesson lesson = new Lesson(date, time, Collections.emptyList());
+        Lesson lesson = new Lesson(date, time, Collections.emptyList(), Collections.emptyMap());
         lesson.addStudent(student1);
         assertTrue(lesson.getStudents().contains(student1));
     }
 
     @Test
     public void removeStudent_success() {
-        Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2));
+        Lesson lesson = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
         lesson.removeStudent(student1);
         assertTrue(!lesson.getStudents().contains(student1));
     }
 
     @Test
     public void equals_sameAttributes_returnsTrue() {
-        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2));
-        Lesson lesson2 = new Lesson(date, time, Arrays.asList(student1, student2));
+        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, true));
+        Lesson lesson2 = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, true));
         assertEquals(lesson1, lesson2);
     }
 
     @Test
     public void equals_differentAttributes_returnsFalse() {
-        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2));
-        Lesson lesson2 = new Lesson(date, new Time("11:00"), Arrays.asList(student1));
+        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
+        Lesson lesson2 = new Lesson(date, new Time("11:00"), Arrays.asList(student1), Map.of(student1, false));
         assertNotEquals(lesson1, lesson2);
     }
 
     @Test
     public void hashCode_sameAttributes_returnsSameHashCode() {
-        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2));
-        Lesson lesson2 = new Lesson(date, time, Arrays.asList(student1, student2));
+        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
+        Lesson lesson2 = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
         assertEquals(lesson1.hashCode(), lesson2.hashCode());
     }
 
     @Test
     public void hashCode_differentAttributes_returnsDifferentHashCode() {
-        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2));
-        Lesson lesson2 = new Lesson(date, new Time("11:00"), Arrays.asList(student1));
+        Lesson lesson1 = new Lesson(date, time, Arrays.asList(student1, student2),
+                Map.of(student1, false, student2, false));
+        Lesson lesson2 = new Lesson(date, new Time("11:00"), Arrays.asList(student1),
+                Map.of(student1, false));
         assertNotEquals(lesson1.hashCode(), lesson2.hashCode());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
@@ -5,14 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.util.Pair;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.consultation.Date;
@@ -27,11 +23,7 @@ public class JsonAdaptedLessonTest {
     private static final String VALID_TIME = "10:00";
     private static final List<JsonAdaptedStudent> VALID_STUDENTS = Collections.singletonList(
             new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()));
-    private static final Map<JsonAdaptedStudent, Boolean> VALID_MAPS = Collections.singletonMap(
-            new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false);
-    private static final Pair<JsonAdaptedStudent, Boolean> VALID_PAIR =
-            new Pair<>(new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false);
-    private static final Set<Pair<JsonAdaptedStudent, Boolean>> VALID_MAP = new HashSet<>(List.of(VALID_PAIR));
+    private static final List<Boolean> VALID_MAP = List.of(false);
     private static final String INVALID_DATE = "invalid-date";
     private static final String INVALID_TIME = "invalid-time";
 
@@ -71,10 +63,8 @@ public class JsonAdaptedLessonTest {
         addressBook.addStudent(student);
 
         JsonAdaptedStudent jsonStudent = new JsonAdaptedStudent(student);
-        HashSet<Pair<JsonAdaptedStudent, Boolean>> hashSet = new HashSet<>(List.of(
-                new Pair<>(jsonStudent, false)));
         JsonAdaptedLesson lesson = new JsonAdaptedLesson(
-                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), hashSet);
+                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), List.of(false));
 
         Lesson modelLesson = lesson.toModelType(addressBook);
         Lesson expectedLesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME),

--- a/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,33 +24,36 @@ public class JsonAdaptedLessonTest {
     private static final String VALID_TIME = "10:00";
     private static final List<JsonAdaptedStudent> VALID_STUDENTS = Collections.singletonList(
             new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()));
+    private static final Map<JsonAdaptedStudent, Boolean> VALID_MAP = Collections.singletonMap(
+            new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false
+    );
     private static final String INVALID_DATE = "invalid-date";
     private static final String INVALID_TIME = "invalid-time";
 
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
-        JsonAdaptedLesson lesson = new JsonAdaptedLesson(null, VALID_TIME, VALID_STUDENTS);
+        JsonAdaptedLesson lesson = new JsonAdaptedLesson(null, VALID_TIME, VALID_STUDENTS, VALID_MAP);
         assertThrows(IllegalValueException.class, () -> lesson.toModelType(new AddressBook()),
                 String.format(JsonAdaptedLesson.MISSING_FIELD_MESSAGE_FORMAT, "Date"));
     }
 
     @Test
     public void toModelType_invalidDateFormat_throwsIllegalValueException() {
-        JsonAdaptedLesson lesson = new JsonAdaptedLesson(INVALID_DATE, VALID_TIME, VALID_STUDENTS);
+        JsonAdaptedLesson lesson = new JsonAdaptedLesson(INVALID_DATE, VALID_TIME, VALID_STUDENTS, VALID_MAP);
         assertThrows(IllegalValueException.class, () -> lesson.toModelType(new AddressBook()),
                 Date.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void toModelType_nullTime_throwsIllegalValueException() {
-        JsonAdaptedLesson lesson = new JsonAdaptedLesson(VALID_DATE, null, VALID_STUDENTS);
+        JsonAdaptedLesson lesson = new JsonAdaptedLesson(VALID_DATE, null, VALID_STUDENTS, VALID_MAP);
         assertThrows(IllegalValueException.class, () -> lesson.toModelType(new AddressBook()),
                 String.format(JsonAdaptedLesson.MISSING_FIELD_MESSAGE_FORMAT, "Time"));
     }
 
     @Test
     public void toModelType_invalidTimeFormat_throwsIllegalValueException() {
-        JsonAdaptedLesson lesson = new JsonAdaptedLesson(VALID_DATE, INVALID_TIME, VALID_STUDENTS);
+        JsonAdaptedLesson lesson = new JsonAdaptedLesson(VALID_DATE, INVALID_TIME, VALID_STUDENTS, VALID_MAP);
         assertThrows(IllegalValueException.class, () -> lesson.toModelType(new AddressBook()),
                 Time.MESSAGE_CONSTRAINTS);
     }
@@ -62,10 +66,12 @@ public class JsonAdaptedLessonTest {
         addressBook.addStudent(student);
 
         JsonAdaptedStudent jsonStudent = new JsonAdaptedStudent(student);
-        JsonAdaptedLesson lesson = new JsonAdaptedLesson(VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent));
+        JsonAdaptedLesson lesson = new JsonAdaptedLesson(
+                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), Collections.singletonMap(jsonStudent, false));
 
         Lesson modelLesson = lesson.toModelType(addressBook);
-        Lesson expectedLesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME), Arrays.asList(student));
+        Lesson expectedLesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME),
+                Arrays.asList(student), Collections.singletonMap(student, false));
 
         assertEquals(expectedLesson, modelLesson);
     }
@@ -74,7 +80,8 @@ public class JsonAdaptedLessonTest {
     public void jsonAdaptedLesson_fromLesson_success() {
         // Create a Lesson instance
         Student student = new StudentBuilder().withName("Alice Pauline").build();
-        Lesson lesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME), Arrays.asList(student));
+        Lesson lesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME),
+                Arrays.asList(student), Collections.singletonMap(student, false));
 
         // Convert the Lesson to JsonAdaptedLesson
         JsonAdaptedLesson jsonAdaptedLesson = new JsonAdaptedLesson(lesson);

--- a/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.util.Pair;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.consultation.Date;
@@ -24,9 +27,11 @@ public class JsonAdaptedLessonTest {
     private static final String VALID_TIME = "10:00";
     private static final List<JsonAdaptedStudent> VALID_STUDENTS = Collections.singletonList(
             new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()));
-    private static final Map<JsonAdaptedStudent, Boolean> VALID_MAP = Collections.singletonMap(
-            new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false
-    );
+    private static final Map<JsonAdaptedStudent, Boolean> VALID_MAPS = Collections.singletonMap(
+            new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false);
+    private static final Pair<JsonAdaptedStudent, Boolean> VALID_PAIR =
+            new Pair<>(new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false);
+    private static final Set<Pair<JsonAdaptedStudent, Boolean>> VALID_MAP = new HashSet<>(List.of(VALID_PAIR));
     private static final String INVALID_DATE = "invalid-date";
     private static final String INVALID_TIME = "invalid-time";
 
@@ -66,8 +71,10 @@ public class JsonAdaptedLessonTest {
         addressBook.addStudent(student);
 
         JsonAdaptedStudent jsonStudent = new JsonAdaptedStudent(student);
+        HashSet<Pair<JsonAdaptedStudent, Boolean>> hashSet = new HashSet<>(List.of(
+                new Pair<>(jsonStudent, false)));
         JsonAdaptedLesson lesson = new JsonAdaptedLesson(
-                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), Collections.singletonMap(jsonStudent, false));
+                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), hashSet);
 
         Lesson modelLesson = lesson.toModelType(addressBook);
         Lesson expectedLesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME),

--- a/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedLessonTest.java
@@ -23,7 +23,10 @@ public class JsonAdaptedLessonTest {
     private static final String VALID_TIME = "10:00";
     private static final List<JsonAdaptedStudent> VALID_STUDENTS = Collections.singletonList(
             new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()));
-    private static final List<Boolean> VALID_MAP = List.of(false);
+    private static final List<Boolean> VALID_MAPS = List.of(false);
+    private static final List<Pair<JsonAdaptedStudent, Boolean>> VALID_MAP = Collections.singletonList(new Pair<>(
+            new JsonAdaptedStudent(new StudentBuilder().withName("Alice Pauline").build()), false));
+
     private static final String INVALID_DATE = "invalid-date";
     private static final String INVALID_TIME = "invalid-time";
 
@@ -64,7 +67,7 @@ public class JsonAdaptedLessonTest {
 
         JsonAdaptedStudent jsonStudent = new JsonAdaptedStudent(student);
         JsonAdaptedLesson lesson = new JsonAdaptedLesson(
-                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), List.of(false));
+                VALID_DATE, VALID_TIME, Arrays.asList(jsonStudent), List.of(new Pair<>(jsonStudent, false)));
 
         Lesson modelLesson = lesson.toModelType(addressBook);
         Lesson expectedLesson = new Lesson(new Date(VALID_DATE), new Time(VALID_TIME),

--- a/src/test/java/seedu/address/testutil/LessonBuilder.java
+++ b/src/test/java/seedu/address/testutil/LessonBuilder.java
@@ -3,7 +3,9 @@ package seedu.address.testutil;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import seedu.address.model.consultation.Date;
 import seedu.address.model.consultation.Time;
@@ -20,6 +22,7 @@ public class LessonBuilder {
     private Date date;
     private Time time;
     private final List<Student> students;
+    private final Map<Student, Boolean> attendanceMap;
 
     /**
      * Creates a {@code LessonBuilder} with the default details.
@@ -28,6 +31,7 @@ public class LessonBuilder {
         date = new Date(DEFAULT_DATE);
         time = new Time(DEFAULT_TIME);
         students = new ArrayList<>();
+        attendanceMap = new HashMap<>();
     }
 
     /**
@@ -37,6 +41,7 @@ public class LessonBuilder {
         date = lessonToCopy.getDate();
         time = lessonToCopy.getTime();
         students = new ArrayList<>(lessonToCopy.getStudents());
+        attendanceMap = new HashMap<>(lessonToCopy.getAttendanceMap());
     }
 
     /**
@@ -61,6 +66,16 @@ public class LessonBuilder {
     public LessonBuilder withStudent(Student student) {
         requireNonNull(student);
         this.students.add(student);
+        this.attendanceMap.put(student, false); // Student must also be added to the attendanceMap
+        return this;
+    }
+
+    /**
+     * Sets the {@code Student}'s attendance in the {@code Lesson} we are building.
+     */
+    public LessonBuilder withAttendance(Student student, boolean attendance) {
+        requireNonNull(student);
+        this.attendanceMap.put(student, attendance);
         return this;
     }
 
@@ -68,6 +83,6 @@ public class LessonBuilder {
      * Builds and returns the Lesson.
      */
     public Lesson build() {
-        return new Lesson(date, time, students);
+        return new Lesson(date, time, students, attendanceMap);
     }
 }


### PR DESCRIPTION
Closes #171.

This PR:
- Adds a field `attendanceMap` in `Lesson` that uses a `HashMap` to store students' attendance boolean.
- Implements a generic `Pair` wrapper class because JavaFX's version does not play nice with GitHub CI.
- Updates Storage to handle `attendanceMap`. Note that `List<Pair<JsonAdaptedStudent, Boolean>>` is used instead of `HashMap` because `HashMap` does not have a compatible map key deserialiser to be used in Jackson (I have no idea how to implement this).
- Updates existing testcases.

Of note is that:
- In the constructor for `Lesson`, any students in the student list **must** be present in the `attendanceMap`.
- However, in `JsonAdaptedLesson`, if a student is not found in the `attendanceMap` when reading from the JSON file, the attendance is set to `false` for that particular student as a default.

This is because extensive changes to the sample test data would be needed to prevent the code from throwing errors if it were to enforce the same rule in `JsonAdaptedLesson`. We would need to add the representation of `Set<Pair<JsonAdaptedStudent, Boolean>>` as attendance data for each student in a lesson, which I currently do not know how to do.

Additionally, this behavior may be desired because a mistaken edit to the JSON file or corrupted data would not cause the entire program to crash.