### PR TITLE
Add indices for add to consult

### DIFF
--- a/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
@@ -4,7 +4,11 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONSULTATION_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -33,27 +37,38 @@ public class AddToConsultCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 n/John Doe n/Harry Ng";
 
     public static final String MESSAGE_ADD_TO_CONSULT_SUCCESS = "Added students to the Consultation: %1$s";
-    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION = "%s is already added to the consultation!";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME
+            = "%s is already added to the consultation!";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX
+            = "%s at index %d is already added to the consultation!";
+
+
 
     private final Index index;
     private final List<Name> studentNames;
+    private final List<Index> indices;
 
     /**
      * @param index of the consultation in the filtered consultation list
      * @param studentNames list of student names to add to the consultation
+     * @param indices list of indices of students in the current filtered list to add to the current consultation
      */
-    public AddToConsultCommand(Index index, List<Name> studentNames) {
+    public AddToConsultCommand(Index index, List<Name> studentNames, List<Index> indices) {
         requireNonNull(index);
         requireNonNull(studentNames);
+        requireNonNull(indices);
+
 
         this.index = index;
         this.studentNames = studentNames;
+        this.indices = indices;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Consultation> lastShownList = model.getFilteredConsultationList();
+        List<Student> lastShownStudentList = model.getFilteredStudentList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(String.format(MESSAGE_INVALID_CONSULTATION_DISPLAYED_INDEX,
@@ -70,7 +85,38 @@ public class AddToConsultCommand extends Command {
                 editedConsultation.addStudent(student);
             } catch (DuplicateStudentException e) {
                 throw new CommandException(
-                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION, studentName));
+                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME, studentName));
+            }
+        }
+
+        // check if any of the indices are out of bounds of the filtered student list
+        boolean throwException = false;
+        Set<Index> outOfBounds = new HashSet<>();
+
+        for (Index item: indices) {
+            if (item.getZeroBased() >= lastShownStudentList.size()) {
+                throwException = true;
+                outOfBounds.add(item);
+            }
+        }
+
+        if (throwException) {
+            String formattedOutOfBoundIndices = outOfBounds.stream()
+                    .map(index -> String.valueOf(index.getOneBased()))
+                    .collect(Collectors.joining(", "));
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN, formattedOutOfBoundIndices));
+        }
+
+        // Make sure that there are no duplicate students. Since logic handling duplicate students is done here for
+        // adding students by name, logic for handling duplicate indices are also handled here
+        for (Index studentIndices : indices) {
+            Student student = lastShownStudentList.get(studentIndices.getZeroBased());
+            try {
+                editedConsultation.addStudent(student);
+            } catch (DuplicateStudentException e) {
+                throw new CommandException(
+                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX, student.getName(),
+                                studentIndices.getOneBased()));
             }
         }
 

--- a/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONSULTATION_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,10 +36,12 @@ public class AddToConsultCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 n/John Doe n/Harry Ng";
 
     public static final String MESSAGE_ADD_TO_CONSULT_SUCCESS = "Added students to the Consultation: %1$s";
-    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME
-            = "%s is already added to the consultation!";
-    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX
-            = "%s at index %d is already added to the consultation!";
+
+    public static final String MESSAGE_STUDENT_NOT_FOUND = "Student(s) %s not found";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME =
+            "%s is already added to the consultation!";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX =
+            "%s at index %d is already added to the consultation!";
 
 
 
@@ -80,7 +81,8 @@ public class AddToConsultCommand extends Command {
 
         for (Name studentName : studentNames) {
             Student student = model.findStudentByName(studentName)
-                    .orElseThrow(() -> new CommandException("Student not found: " + studentName));
+                    .orElseThrow(() -> new CommandException(
+                            String.format(MESSAGE_STUDENT_NOT_FOUND, studentName)));
             try {
                 editedConsultation.addStudent(student);
             } catch (DuplicateStudentException e) {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_TIME = new Prefix("t/");;
+    public static final Prefix PREFIX_TIME = new Prefix("t/");
     public static final Prefix PREFIX_INDEX = new Prefix("i/");
     public static final Prefix DEFAULT_DELIMITER = new Prefix(";");
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_TIME = new Prefix("t/");
+    public static final Prefix PREFIX_TIME = new Prefix("t/");;
+    public static final Prefix PREFIX_INDEX = new Prefix("i/");
     public static final Prefix DEFAULT_DELIMITER = new Prefix(";");
 
 }

--- a/src/main/java/seedu/address/logic/parser/consultation/AddToConsultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultation/AddToConsultCommandParser.java
@@ -6,9 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.consultation.AddToConsultCommand;

--- a/src/main/java/seedu/address/logic/parser/consultation/AddToConsultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultation/AddToConsultCommandParser.java
@@ -2,10 +2,13 @@ package seedu.address.logic.parser.consultation;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.consultation.AddToConsultCommand;
@@ -30,7 +33,7 @@ public class AddToConsultCommandParser implements Parser<AddToConsultCommand> {
     public AddToConsultCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_INDEX);
 
         Index index;
 
@@ -41,7 +44,7 @@ public class AddToConsultCommandParser implements Parser<AddToConsultCommand> {
                 AddToConsultCommand.MESSAGE_USAGE), pe);
         }
 
-        if (argMultimap.getAllValues(PREFIX_NAME).isEmpty()) {
+        if (argMultimap.getAllValues(PREFIX_NAME).isEmpty() && argMultimap.getAllValues(PREFIX_INDEX).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToConsultCommand.MESSAGE_USAGE));
         }
 
@@ -57,6 +60,14 @@ public class AddToConsultCommandParser implements Parser<AddToConsultCommand> {
             studentNames.add(name);
         }
 
-        return new AddToConsultCommand(index, studentNames);
+
+        List<Index> indices = new ArrayList<>();
+        for (String stringNameIndex: argMultimap.getAllValues(PREFIX_INDEX)) {
+            // throws ParseException, with the message being invalid index
+            Index nameIndex = ParserUtil.parseIndex(stringNameIndex);
+            indices.add(nameIndex);
+        }
+
+        return new AddToConsultCommand(index, studentNames, indices);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -38,6 +39,7 @@ public class CommandTestUtil {
 
     public static final String SPACED_PREFIX_NAME = " " + PREFIX_NAME;
     public static final String SPACED_PREFIX_COURSE = " " + PREFIX_COURSE;
+    public static final String SPACED_PREFIX_INDEX = " " + PREFIX_INDEX;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
@@ -36,23 +36,9 @@ public class AddToConsultCommandTest {
 
     private Model model;
 
-    private final String index1 = "1";
-    private final Index validConsultIndex = Index.fromOneBased(Integer.parseInt(index1));
-    private final ObservableList<Name> studentNames = FXCollections.observableArrayList(
-            new Name(AMY.getName().fullName),
-            new Name(BOB.getName().fullName));
-
-    private final ObservableList<Name> duplicateStudentNames = FXCollections.observableArrayList(
-            new Name(AMY.getName().fullName),
-            new Name(AMY.getName().fullName));
-
-    private final ObservableList<Index> studentIndices = FXCollections.observableArrayList(
-            INDEX_FIRST_STUDENT,
-            INDEX_SECOND_STUDENT);
-
-    private final ObservableList<Index> duplicateStudentIndices = FXCollections.observableArrayList(
-            INDEX_FIRST_STUDENT,
-            INDEX_FIRST_STUDENT);
+    private final Index validConsultIndex = Index.fromOneBased(1);
+    private final ObservableList<Name> studentNames = FXCollections.observableArrayList(new Name(AMY.getName().fullName), new Name(BOB.getName().fullName));
+    private final ObservableList<Index> studentIndices = FXCollections.observableArrayList(INDEX_FIRST_STUDENT, INDEX_SECOND_STUDENT);
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
@@ -1,113 +1,234 @@
 package seedu.address.logic.commands.consultation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONSULTATION_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showStudentAtIndex;
+import static seedu.address.logic.commands.consultation.AddToConsultCommand.MESSAGE_ADD_TO_CONSULT_SUCCESS;
+import static seedu.address.logic.commands.consultation.AddToConsultCommand.MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX;
+import static seedu.address.logic.commands.consultation.AddToConsultCommand.MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME;
+import static seedu.address.logic.commands.consultation.AddToConsultCommand.MESSAGE_STUDENT_NOT_FOUND;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalConsultations.getTypicalConsultations;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
+import static seedu.address.testutil.TypicalStudents.ALICE;
 import static seedu.address.testutil.TypicalStudents.AMY;
+import static seedu.address.testutil.TypicalStudents.BENSON;
 import static seedu.address.testutil.TypicalStudents.BOB;
+import static seedu.address.testutil.TypicalStudents.CARL;
+import static seedu.address.testutil.TypicalStudents.DANIEL;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Name;
-import seedu.address.model.student.Student;
-
 public class AddToConsultCommandTest {
 
     private Model model;
 
-    private final Index validConsultIndex = Index.fromOneBased(1);
-    private final ObservableList<Name> studentNames = FXCollections.observableArrayList(new Name(AMY.getName().fullName), new Name(BOB.getName().fullName));
-    private final ObservableList<Index> studentIndices = FXCollections.observableArrayList(INDEX_FIRST_STUDENT, INDEX_SECOND_STUDENT);
+
+    private final Index validConsultIndex1WithAlice = Index.fromOneBased(1);
+    private final Index validConsultIndex5 = Index.fromOneBased(5);
+    private final ObservableList<Name> allInvalidStudentNames = FXCollections.observableArrayList(
+            new Name(AMY.getName().fullName), new Name(BOB.getName().fullName));
+    private final ObservableList<Name> someInvalidStudentNames = FXCollections.observableArrayList(
+            new Name(CARL.getName().fullName), new Name(BOB.getName().fullName));
+    private final ObservableList<Name> validStudentNames = FXCollections.observableArrayList(
+            new Name(CARL.getName().fullName), new Name(DANIEL.getName().fullName));
+    private final ObservableList<Name> duplicateStudentNames = FXCollections.observableArrayList(
+            new Name(CARL.getName().fullName), new Name(CARL.getName().fullName));
+    private final ObservableList<Index> validStudentIndices = FXCollections.observableArrayList(
+            INDEX_FIRST_STUDENT, INDEX_SECOND_STUDENT); //contains Alice and Bob
+    private ObservableList<Index> invalidIndices;
 
     @BeforeEach
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        invalidIndices = FXCollections.observableArrayList(
+                Index.fromOneBased(model.getFilteredStudentList().size() + 1));
     }
 
     @Test
-    public void execute_addStudentsToConsult_success() throws Exception {
-        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex, studentNames, studentIndices);
+    public void execute_addStudentsToConsultNamesAndIndices_success() throws Exception {
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                validStudentNames, validStudentIndices);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
         CommandResult result = command.execute(model);
-        Consultation consultation = model.getFilteredConsultationList().get(validConsultIndex.getZeroBased());
 
-        assertEquals(5, consultation.getStudents().size()); // 2 from names, 2 from indices, and 1 existing student
+        Consultation targetConsultation = expectedModel.getFilteredConsultationList()
+                .get(validConsultIndex5.getZeroBased());
+        Consultation editedConsultation = new Consultation(targetConsultation);
+
+        editedConsultation.addStudent(CARL);
+        editedConsultation.addStudent(DANIEL);
+        editedConsultation.addStudent(ALICE);
+        editedConsultation.addStudent(BENSON);
+        expectedModel.setConsult(targetConsultation, editedConsultation);
+
+        String expectedMessage = String.format(MESSAGE_ADD_TO_CONSULT_SUCCESS, Messages.format(editedConsultation));
+
+        assertEquals(result.getFeedbackToUser(), expectedMessage);
+        assertEquals(expectedModel.getFilteredConsultationList().get(validConsultIndex5.getZeroBased()),
+                model.getFilteredConsultationList().get(validConsultIndex5.getZeroBased()));
+    }
+
+    @Test
+    public void execute_addStudentsToConsultIndicesOnly_success() throws Exception {
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                FXCollections.observableArrayList(), validStudentIndices);
+
+        CommandResult result = command.execute(model);
+        Consultation consultation = model.getFilteredConsultationList().get(validConsultIndex5.getZeroBased());
+
+        assertEquals(2, consultation.getStudents().size()); // 2 from indices
+    }
+
+    @Test
+    public void execute_addStudentsToConsultNamesOnly_success() throws Exception {
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                validStudentNames, FXCollections.observableArrayList());
+
+        CommandResult result = command.execute(model);
+        Consultation consultation = model.getFilteredConsultationList().get(validConsultIndex5.getZeroBased());
+
+        assertEquals(2, consultation.getStudents().size()); // 2 from names
     }
 
     @Test
     public void execute_invalidConsultationIndex_throwsCommandException() {
         Index invalidConsultIndex = Index.fromOneBased(model.getFilteredConsultationList().size() + 1);
-        AddToConsultCommand command = new AddToConsultCommand(invalidConsultIndex, studentNames, studentIndices);
+        AddToConsultCommand command = new AddToConsultCommand(invalidConsultIndex,
+                validStudentNames, validStudentIndices);
 
-        assertThrows(CommandException.class, () -> command.execute(model));
+        assertCommandFailure(command, model, String.format(MESSAGE_INVALID_CONSULTATION_DISPLAYED_INDEX,
+                invalidConsultIndex.getOneBased()));
     }
 
     @Test
     public void execute_invalidStudentIndices_throwsCommandException() {
-        ObservableList<Index> invalidIndices = FXCollections.observableArrayList(Index.fromOneBased(model.getFilteredStudentList().size() + 1));
-        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex, studentNames, invalidIndices);
+
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                validStudentNames, invalidIndices);
 
         String formattedOutOfBoundIndices = invalidIndices.stream()
                 .map(index -> String.valueOf(index.getOneBased()))
                 .collect(Collectors.joining(", "));
 
-        assertCommandFailure(command, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN, formattedOutOfBoundIndices));
+        assertCommandFailure(command, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                formattedOutOfBoundIndices));
     }
 
     @Test
-    public void execute_someOfManyInvalidIndexUnfilteredList_throwsCommandException() {
-        ObservableList<Index> someInvalidIndices = FXCollections.observableArrayList(Index.fromOneBased(model.getFilteredStudentList().size() + 1), INDEX_FIRST_STUDENT);
-        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex, studentNames, someInvalidIndices);
+    public void execute_invalidStudentNames_throwsCommandException() {
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                allInvalidStudentNames, validStudentIndices);
+
+        String studentNotFoundMessage = String.format(MESSAGE_STUDENT_NOT_FOUND , AMY.getName());
+
+        assertCommandFailure(command, model, studentNotFoundMessage);
+    }
+
+    @Test
+    public void execute_someOfManyInvalidIndex_throwsCommandException() {
+        ObservableList<Index> someInvalidIndices = FXCollections.observableArrayList(
+                Index.fromOneBased(model.getFilteredStudentList().size() + 1), INDEX_FIRST_STUDENT);
+        AddToConsultCommand command = new AddToConsultCommand(
+                validConsultIndex5, validStudentNames, someInvalidIndices);
 
         String formattedOutOfBoundIndices = String.valueOf(model.getFilteredStudentList().size() + 1);
 
-        assertCommandFailure(command, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN, formattedOutOfBoundIndices));
+        assertCommandFailure(command, model, String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                formattedOutOfBoundIndices));
     }
 
     @Test
-    public void execute_duplicateStudentByIndex_throwsCommandException() throws Exception {
-        ObservableList<Index> duplicateIndices = FXCollections.observableArrayList(INDEX_FIRST_STUDENT, INDEX_FIRST_STUDENT);
-        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex, FXCollections.observableArrayList(), duplicateIndices);
+    public void execute_someOfManyInvalidNames_throwsCommandException() {
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                someInvalidStudentNames, validStudentIndices);
 
-        assertThrows(CommandException.class, () -> command.execute(model), "Expected duplicate student exception.");
+        String studentNotFoundMessage = String.format(MESSAGE_STUDENT_NOT_FOUND , BOB.getName());
+
+        assertCommandFailure(command, model, studentNotFoundMessage);
+    }
+
+    @Test
+    public void execute_duplicateStudentByIndex_throwsCommandException() {
+        ObservableList<Index> duplicateIndices = FXCollections.observableArrayList(
+                INDEX_FIRST_STUDENT, INDEX_FIRST_STUDENT);
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                validStudentNames, duplicateIndices);
+
+        String error = String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX, ALICE.getName().fullName,
+                INDEX_FIRST_STUDENT.getOneBased());
+
+        assertCommandFailure(command, model, error);
+    }
+
+    @Test
+    public void execute_duplicateStudentInExistingAndIndex_throwsCommandException() {
+        ObservableList<Index> validIndicesWithAlice = FXCollections.observableArrayList(
+                INDEX_FIRST_STUDENT, INDEX_SECOND_STUDENT);
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex1WithAlice,
+                validStudentNames, validIndicesWithAlice);
+
+        String error = String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX, ALICE.getName().fullName,
+                INDEX_FIRST_STUDENT.getOneBased());
+
+        assertCommandFailure(command, model, error);
+    }
+
+    @Test
+    public void execute_duplicateStudentInExistingAndName_throwsCommandException() {
+        ObservableList<Name> validNamesWithAlice = FXCollections.observableArrayList(
+                new Name(ALICE.getName().fullName), new Name(CARL.getName().fullName));
+        ObservableList<Index> validIndicesWithoutAlice = FXCollections.observableArrayList(
+                INDEX_SECOND_STUDENT);
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex1WithAlice,
+                validNamesWithAlice, validIndicesWithoutAlice);
+
+        String duplicateStudentInConsultError = String.format(
+                MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME, ALICE.getName());
+
+        assertCommandFailure(command, model, duplicateStudentInConsultError);
+    }
+
+    @Test
+    public void execute_duplicateStudentByName_throwsCommandException() {
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                duplicateStudentNames, validStudentIndices);
+
+        String error = String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME, CARL.getName().fullName);
+
+        assertCommandFailure(command, model, error);
     }
 
     @Test
     public void execute_validIndexFilteredList_success() throws Exception {
         showStudentAtIndex(model, INDEX_FIRST_STUDENT);
 
-        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex, FXCollections.observableArrayList(), studentIndices);
+        ObservableList<Index> validIndex = FXCollections.observableArrayList(
+                INDEX_FIRST_STUDENT);
+
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                FXCollections.observableArrayList(), validIndex);
 
         CommandResult result = command.execute(model);
-        Consultation consultation = model.getFilteredConsultationList().get(validConsultIndex.getZeroBased());
+        Consultation consultation = model.getFilteredConsultationList().get(validConsultIndex5.getZeroBased());
 
-        assertEquals(3, consultation.getStudents().size()); // 1 existing + 2 added by index
-    }
-
-    // Additional utility to match typical setup for filtered list views
-    private void showNoStudent(Model model) {
-        model.updateFilteredStudentList(p -> false);
-        assertEquals(0, model.getFilteredStudentList().size());
+        assertEquals(1, consultation.getStudents().size()); // 1 existing
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.SPACED_PREFIX_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.SPACED_PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONSULT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
@@ -110,18 +112,21 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_addToConsult() throws Exception {
         // Construct the input arguments for the AddToConsultCommand
-        Index index = Index.fromOneBased(1);
+        String index1 = "1";
+        Index index = Index.fromOneBased(Integer.parseInt(index1));
         String name1 = "John Doe";
         String name2 = "Harry Ng";
 
-        String input = String.format("%s %d n/%s n/%s", AddToConsultCommand.COMMAND_WORD,
-                index.getOneBased(), name1, name2);
+        String input = AddToConsultCommand.COMMAND_WORD + " " + index.getOneBased()
+                        + SPACED_PREFIX_NAME + name1 + SPACED_PREFIX_NAME + name2
+                + SPACED_PREFIX_INDEX + index1;
 
         AddToConsultCommand command = (AddToConsultCommand) parser.parseCommand(input);
 
         // Construct the expected command
         List<Name> expectedNames = List.of(new Name(name1), new Name(name2));
-        AddToConsultCommand expectedCommand = new AddToConsultCommand(index, expectedNames);
+        List<Index> expectedIndices = List.of(index);
+        AddToConsultCommand expectedCommand = new AddToConsultCommand(index, expectedNames, expectedIndices);
 
         // Assert that the parsed command is equal to the expected command
         assertEquals(expectedCommand, command);

--- a/src/test/java/seedu/address/logic/parser/consultation/AddToConsultCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/consultation/AddToConsultCommandParserTest.java
@@ -18,21 +18,20 @@ import seedu.address.model.student.Name;
 
 public class AddToConsultCommandParserTest {
 
+    private static final List<Index> EMPTY_INDEX_LIST = new ArrayList<>();
+    private static final List<Name> EMPTY_NAME_LIST = new ArrayList<>();
+    private static final String JOHN_STRING = "John Doe";
+    private static final Name JOHN_NAME = new Name(JOHN_STRING);
+    private static final String HARRY_STRING = "Harry Ng";
+    private static final Name HARRY_NAME = new Name(HARRY_STRING);
+    private static final String FIRST_INDEX_STRING = "1";
+    private static final Index FIRST_INDEX = Index.fromOneBased(Integer.parseInt(FIRST_INDEX_STRING));
+    private static final String SECOND_INDEX_STRING = "2";
+    private static final Index SECOND_INDEX = Index.fromOneBased(Integer.parseInt(SECOND_INDEX_STRING));
+    private static final String INVALID_INDEX_NEGATIVE = "-1";
+    private static final String INVALID_INDEX_LETTERS = "ABC";
+
     private AddToConsultCommandParser parser = new AddToConsultCommandParser();
-
-    private final List<Index> EMPTY_INDEX_LIST = new ArrayList<>();
-    private final List<Name> EMPTY_NAME_LIST = new ArrayList<>();
-    private final String JOHN_STRING = "John Doe";
-    private final Name JOHN_NAME = new Name(JOHN_STRING);
-    private final String HARRY_STRING = "Harry Ng";
-    private final Name HARRY_NAME = new Name(HARRY_STRING);
-    private final String FIRST_INDEX_STRING = "1";
-    private final Index FIRST_INDEX = Index.fromOneBased(Integer.parseInt(FIRST_INDEX_STRING));
-    private final String SECOND_INDEX_STRING = "2";
-    private final Index SECOND_INDEX = Index.fromOneBased(Integer.parseInt(SECOND_INDEX_STRING));
-    private final String INVALID_INDEX_NEGATIVE = "-1";
-    private final String INVALID_INDEX_LETTERS = "ABC";
-
 
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/consultation/AddToConsultCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/consultation/AddToConsultCommandParserTest.java
@@ -1,9 +1,13 @@
 package seedu.address.logic.parser.consultation;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.SPACED_PREFIX_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.SPACED_PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -16,26 +20,76 @@ public class AddToConsultCommandParserTest {
 
     private AddToConsultCommandParser parser = new AddToConsultCommandParser();
 
+    private final List<Index> EMPTY_INDEX_LIST = new ArrayList<>();
+    private final List<Name> EMPTY_NAME_LIST = new ArrayList<>();
+    private final String JOHN_STRING = "John Doe";
+    private final Name JOHN_NAME = new Name(JOHN_STRING);
+    private final String HARRY_STRING = "Harry Ng";
+    private final Name HARRY_NAME = new Name(HARRY_STRING);
+    private final String FIRST_INDEX_STRING = "1";
+    private final Index FIRST_INDEX = Index.fromOneBased(Integer.parseInt(FIRST_INDEX_STRING));
+    private final String SECOND_INDEX_STRING = "2";
+    private final Index SECOND_INDEX = Index.fromOneBased(Integer.parseInt(SECOND_INDEX_STRING));
+    private final String INVALID_INDEX_NEGATIVE = "-1";
+    private final String INVALID_INDEX_LETTERS = "ABC";
+
+
+
     @Test
-    public void parse_allFieldsPresent_success() {
+    public void parse_namesPresentEmptyIndex_success() {
         Index index = Index.fromOneBased(1);
-        List<Name> expectedNames = List.of(new Name("John Doe"), new Name("Harry Ng"));
+        List<Name> expectedNames = List.of(JOHN_NAME, HARRY_NAME);
 
         // no whitespaces
-        assertParseSuccess(parser, " 1 n/John Doe n/Harry Ng",
-                new AddToConsultCommand(index, expectedNames));
+        assertParseSuccess(parser, " 1" + SPACED_PREFIX_NAME + JOHN_STRING + SPACED_PREFIX_NAME + HARRY_STRING,
+                new AddToConsultCommand(index, expectedNames, EMPTY_INDEX_LIST));
 
         // random whitespaces
-        assertParseSuccess(parser, "  \n \t 1 \n n/John Doe  \t n/Harry Ng  ",
-                new AddToConsultCommand(index, expectedNames));
+        assertParseSuccess(parser, "  \n \t 1 \n" + SPACED_PREFIX_NAME + JOHN_STRING
+                        + "  \t" + SPACED_PREFIX_NAME + HARRY_STRING + "  ",
+                new AddToConsultCommand(index, expectedNames, EMPTY_INDEX_LIST));
     }
 
     @Test
-    public void parse_missingNames_failure() {
+    public void parse_indicesPresentEmptyName_success() {
+        List<Index> expectedIndices = List.of(FIRST_INDEX, SECOND_INDEX);
+
+        // no whitespaces
+        assertParseSuccess(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING + SPACED_PREFIX_INDEX
+                        + SECOND_INDEX_STRING,
+                new AddToConsultCommand(FIRST_INDEX, EMPTY_NAME_LIST, expectedIndices));
+
+        // random whitespaces
+        assertParseSuccess(parser, "  \n \t" + FIRST_INDEX_STRING + " \n" + SPACED_PREFIX_INDEX
+                        + FIRST_INDEX_STRING + "  \t" + SPACED_PREFIX_INDEX + SECOND_INDEX_STRING + "  ",
+                new AddToConsultCommand(FIRST_INDEX, EMPTY_NAME_LIST, expectedIndices));
+    }
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        List<Index> expectedIndices = List.of(FIRST_INDEX, SECOND_INDEX);
+        List<Name> expectedNames = List.of(JOHN_NAME, HARRY_NAME);
+        // no whitespaces
+        assertParseSuccess(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING
+                        + SPACED_PREFIX_INDEX + SECOND_INDEX_STRING + SPACED_PREFIX_NAME + JOHN_STRING
+                        + SPACED_PREFIX_NAME + HARRY_STRING,
+                new AddToConsultCommand(FIRST_INDEX, expectedNames, expectedIndices));
+
+        // random whitespaces
+        assertParseSuccess(parser, "  \n \t" + FIRST_INDEX_STRING + " \n" + SPACED_PREFIX_INDEX
+                        + "  \t" + FIRST_INDEX_STRING
+                        + SPACED_PREFIX_INDEX + "    " + SECOND_INDEX_STRING + SPACED_PREFIX_NAME + JOHN_STRING
+                        + SPACED_PREFIX_NAME + HARRY_STRING,
+                new AddToConsultCommand(FIRST_INDEX, expectedNames, expectedIndices));
+    }
+
+
+    @Test
+    public void parse_missingNamesAndIndices_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToConsultCommand.MESSAGE_USAGE);
 
         // missing student names
-        assertParseFailure(parser, " 1 ", expectedMessage);
+        assertParseFailure(parser, " " + FIRST_INDEX_STRING + " ", expectedMessage);
 
         // missing index and student names
         assertParseFailure(parser, " ", expectedMessage);
@@ -46,18 +100,21 @@ public class AddToConsultCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToConsultCommand.MESSAGE_USAGE);
 
         // invalid index
-        assertParseFailure(parser, " -1 n/John Doe", expectedMessage);
+        assertParseFailure(parser, " " + INVALID_INDEX_NEGATIVE + SPACED_PREFIX_NAME + JOHN_STRING
+                + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING, expectedMessage);
 
         // non-numeric index
-        assertParseFailure(parser, " abc n/John Doe", expectedMessage);
+        assertParseFailure(parser, " " + INVALID_INDEX_LETTERS
+                + SPACED_PREFIX_INDEX + SECOND_INDEX_STRING, expectedMessage);
     }
 
     @Test
     public void parse_invalidName_failure() {
         // invalid name (empty name)
-        assertParseFailure(parser, " 1 n/", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME, Name.MESSAGE_CONSTRAINTS);
 
         // invalid name (numbers in name)
-        assertParseFailure(parser, " 1 n/1234", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME
+                + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS);
     }
 }


### PR DESCRIPTION
Fixes #170 

Added support for passing indices when adding students.

Sample usage:
`addtoconsult 1 n/Harry Ng n/John Doe i/1 i/2`

This command adds students at index 1 and 2 and Harry Ng and John Doe students to first index of the filtered consultation list

See #170 for more details