### PR TITLE
Add indices for add to lesson

### DIFF
--- a/src/main/java/seedu/address/logic/commands/lesson/AddToLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/lesson/AddToLessonCommand.java
@@ -4,8 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
@@ -29,53 +34,102 @@ public class AddToLessonCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds students to the lesson identified "
             + "by the index number used in the displayed lesson list. "
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME]...\n"
-            + "Example: " + COMMAND_WORD + " 1 n/John Doe n/Harry Ng";
+            + "[" + PREFIX_NAME + "NAME]..."
+            + "[i/INDEX]..."
+            + "\nExample: " + COMMAND_WORD + " 1 n/John Doe i/2";
 
     public static final String MESSAGE_ADD_TO_LESSON_SUCCESS = "Added students to the Lesson: %1$s";
-    public static final String MESSAGE_DUPLICATE_STUDENT_IN_LESSON = "%s is already added to the lesson!";
+    public static final String MESSAGE_STUDENT_NOT_FOUND = "Student not found: %s";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_LESSON_BY_NAME =
+            "%s is already added to the lesson!";
+    public static final String MESSAGE_DUPLICATE_STUDENT_IN_LESSON_BY_INDEX =
+            "%s at index %d is already added to the lesson!";
 
     private final Index index;
     private final List<Name> studentNames;
+    private final List<Index> indices;
+    private final Logger logger = LogsCenter.getLogger(AddToLessonCommand.class);
 
     /**
-     * @param index        of the lesson in the filtered lesson list
+     * @param index of the lesson in the filtered lesson list
      * @param studentNames list of student names to add to the lesson
+     * @param indices list of indices of students in the current filtered list to add to the lesson
      */
-    public AddToLessonCommand(Index index, List<Name> studentNames) {
+    public AddToLessonCommand(Index index, List<Name> studentNames, List<Index> indices) {
         requireNonNull(index);
         requireNonNull(studentNames);
+        requireNonNull(indices);
 
         this.index = index;
         this.studentNames = studentNames;
+        this.indices = indices;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Lesson> lastShownList = model.getFilteredLessonList();
+        logger.info("Adding students to lesson");
+        List<Lesson> lastShownLessonList = model.getFilteredLessonList();
+        List<Student> lastShownStudentList = model.getFilteredStudentList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (index.getZeroBased() >= lastShownLessonList.size()) {
             throw new CommandException(String.format(MESSAGE_INVALID_LESSON_DISPLAYED_INDEX,
                     index.getOneBased()));
         }
 
-        Lesson targetLesson = lastShownList.get(index.getZeroBased());
+        Lesson targetLesson = lastShownLessonList.get(index.getZeroBased());
         Lesson editedLesson = new Lesson(targetLesson);
+
+        logger.info("Lesson to edit: " + targetLesson.toString());
 
         for (Name studentName : studentNames) {
             Student student = model.findStudentByName(studentName)
-                    .orElseThrow(() -> new CommandException("Student not found: " + studentName));
+                    .orElseThrow(() -> new CommandException(String.format(MESSAGE_STUDENT_NOT_FOUND, studentName)));
             try {
                 editedLesson.addStudent(student);
             } catch (DuplicateStudentException e) {
+                logger.warning("Students were not added to lesson " + targetLesson.toString()
+                        + " because there were duplicate names");
                 throw new CommandException(
-                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_LESSON, studentName));
+                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_LESSON_BY_NAME, studentName));
+            }
+        }
+
+        boolean throwException = false;
+        Set<Index> outOfBounds = new HashSet<>();
+
+        for (Index item : indices) {
+            if (item.getZeroBased() >= lastShownStudentList.size()) {
+                throwException = true;
+                outOfBounds.add(item);
+            }
+        }
+
+        if (throwException) {
+            logger.warning("Students were not added to lesson " + targetLesson.toString()
+                    + " because there were indices of students that were out of bounds");
+            String formattedOutOfBoundIndices = outOfBounds.stream()
+                    .map(index -> String.valueOf(index.getOneBased()))
+                    .collect(Collectors.joining(", "));
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN,
+                    formattedOutOfBoundIndices));
+        }
+
+        for (Index studentIndex : indices) {
+            Student student = lastShownStudentList.get(studentIndex.getZeroBased());
+            try {
+                editedLesson.addStudent(student);
+            } catch (DuplicateStudentException e) {
+                logger.warning("Students were not added to lesson " + targetLesson.toString()
+                        + " because there were duplicate names");
+                throw new CommandException(
+                        String.format(MESSAGE_DUPLICATE_STUDENT_IN_LESSON_BY_INDEX, student.getName(),
+                                studentIndex.getOneBased()));
             }
         }
 
         model.setLesson(targetLesson, editedLesson);
-
+        logger.fine("Successfully added students to lesson " + targetLesson.toString());
         return new CommandResult(
                 String.format(MESSAGE_ADD_TO_LESSON_SUCCESS, Messages.format(editedLesson)),
                 COMMAND_TYPE);

--- a/src/main/java/seedu/address/logic/parser/lesson/AddToLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/lesson/AddToLessonCommandParser.java
@@ -2,11 +2,14 @@ package seedu.address.logic.parser.lesson;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.lesson.AddToLessonCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -21,29 +24,33 @@ import seedu.address.model.student.Name;
  */
 public class AddToLessonCommandParser implements Parser<AddToLessonCommand> {
 
+    private final Logger logger = LogsCenter.getLogger(AddToLessonCommandParser.class);
+
     /**
-     * Parses the given {@code String} of arguments in the context of the
-     * AddToLessonCommand
+     * Parses the given {@code String} of arguments in the context of the AddToLessonCommand
      * and returns an AddToLessonCommand object for execution.
      *
-     * @throws ParseException if the user input does not conform to the expected
-     *                        format
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public AddToLessonCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_INDEX);
 
         Index index;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
+            logger.warning("Index was not provided");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddToLessonCommand.MESSAGE_USAGE), pe);
         }
 
-        if (argMultimap.getAllValues(PREFIX_NAME).isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToLessonCommand.MESSAGE_USAGE));
+        if (argMultimap.getAllValues(PREFIX_NAME).isEmpty() && argMultimap.getAllValues(PREFIX_INDEX).isEmpty()) {
+            logger.warning("No names and no student indices were provided");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddToLessonCommand.MESSAGE_USAGE));
         }
 
         // Parse names
@@ -53,10 +60,18 @@ public class AddToLessonCommandParser implements Parser<AddToLessonCommand> {
                 Name name = ParserUtil.parseName(nameString);
                 studentNames.add(name);
             } catch (ParseException e) {
+                logger.warning("Name " + nameString + " could not be parsed properly");
                 throw new ParseException(Name.MESSAGE_CONSTRAINTS, e);
             }
         }
 
-        return new AddToLessonCommand(index, studentNames);
+        List<Index> indices = new ArrayList<>();
+        for (String stringIndex : argMultimap.getAllValues(PREFIX_INDEX)) {
+            // throws ParseException, with the message being invalid index
+            Index studentIndex = ParserUtil.parseIndex(stringIndex);
+            indices.add(studentIndex);
+        }
+
+        return new AddToLessonCommand(index, studentNames, indices);
     }
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAndConsultationsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAndConsultationsAddressBook.json
@@ -169,14 +169,7 @@
     {
       "date": "2024-11-09",
       "time": "16:00",
-      "students": [
-        {
-          "name": "Carl Kurz",
-          "phone": "95352563",
-          "email": "heinz@example.com",
-          "courses": []
-        }
-      ]
+      "students": []
     }
   ]
 }

--- a/src/test/java/seedu/address/logic/commands/lesson/AddToLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/lesson/AddToLessonCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands.lesson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
@@ -14,10 +13,6 @@ import static seedu.address.testutil.TypicalStudents.BOB;
 import static seedu.address.testutil.TypicalStudents.CARL;
 import static seedu.address.testutil.TypicalStudents.DANIEL;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -28,22 +23,17 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.student.Name;
-import seedu.address.model.student.Student;
-import seedu.address.testutil.ModelStub;
-import seedu.address.testutil.StudentBuilder;
 
 public class AddToLessonCommandTest {
 
     private Model model;
 
-    private final Index validIndex = Index.fromOneBased(1);
     private final Index validLessonIndex1WithAlice = Index.fromOneBased(1);
     private final Index validLessonIndex5 = Index.fromOneBased(5);
     private final ObservableList<Name> allInvalidStudentNames = FXCollections.observableArrayList(

--- a/src/test/java/seedu/address/logic/parser/lesson/AddToLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/lesson/AddToLessonCommandParserTest.java
@@ -1,9 +1,14 @@
 package seedu.address.logic.parser.lesson;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.SPACED_PREFIX_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.SPACED_PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -14,31 +19,89 @@ import seedu.address.model.student.Name;
 
 public class AddToLessonCommandParserTest {
 
+    private static final List<Index> EMPTY_INDEX_LIST = new ArrayList<>();
+    private static final List<Name> EMPTY_NAME_LIST = new ArrayList<>();
+    private static final String JOHN_STRING = "John Doe";
+    private static final Name JOHN_NAME = new Name(JOHN_STRING);
+    private static final String HARRY_STRING = "Harry Ng";
+    private static final Name HARRY_NAME = new Name(HARRY_STRING);
+    private static final String FIRST_INDEX_STRING = "1";
+    private static final Index FIRST_INDEX = Index.fromOneBased(Integer.parseInt(FIRST_INDEX_STRING));
+    private static final String SECOND_INDEX_STRING = "2";
+    private static final Index SECOND_INDEX = Index.fromOneBased(Integer.parseInt(SECOND_INDEX_STRING));
+    private static final String INVALID_INDEX_NEGATIVE = "-1";
+    private static final String INVALID_INDEX_LETTERS = "ABC";
     private AddToLessonCommandParser parser = new AddToLessonCommandParser();
 
+
     @Test
-    public void parse_allFieldsPresent_success() {
+    public void parse_namesPresentEmptyIndex_success() {
         Index index = Index.fromOneBased(1);
-        List<Name> expectedNames = List.of(new Name("John Doe"), new Name("Harry Ng"));
+        List<Name> expectedNames = List.of(JOHN_NAME, HARRY_NAME);
 
         // no whitespaces
-        assertParseSuccess(parser, "1 n/John Doe n/Harry Ng",
-                new AddToLessonCommand(index, expectedNames));
+        assertParseSuccess(parser, " 1" + SPACED_PREFIX_NAME + JOHN_STRING + SPACED_PREFIX_NAME + HARRY_STRING,
+                new AddToLessonCommand(index, expectedNames, EMPTY_INDEX_LIST));
 
         // random whitespaces
-        assertParseSuccess(parser, "  \n \t 1 \n n/John Doe  \t n/Harry Ng  ",
-                new AddToLessonCommand(index, expectedNames));
+        assertParseSuccess(parser, "  \n \t 1 \n" + SPACED_PREFIX_NAME + JOHN_STRING
+                        + "  \t" + SPACED_PREFIX_NAME + HARRY_STRING + "  ",
+                new AddToLessonCommand(index, expectedNames, EMPTY_INDEX_LIST));
     }
 
     @Test
-    public void parse_missingNames_failure() {
+    public void parse_indicesPresentEmptyName_success() {
+        List<Index> expectedIndices = List.of(FIRST_INDEX, SECOND_INDEX);
+
+        // no whitespaces
+        assertParseSuccess(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING + SPACED_PREFIX_INDEX
+                        + SECOND_INDEX_STRING,
+                new AddToLessonCommand(FIRST_INDEX, EMPTY_NAME_LIST, expectedIndices));
+
+        // random whitespaces
+        assertParseSuccess(parser, "  \n \t" + FIRST_INDEX_STRING + " \n" + SPACED_PREFIX_INDEX
+                        + FIRST_INDEX_STRING + "  \t" + SPACED_PREFIX_INDEX + SECOND_INDEX_STRING + "  ",
+                new AddToLessonCommand(FIRST_INDEX, EMPTY_NAME_LIST, expectedIndices));
+    }
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        List<Index> expectedIndices = List.of(FIRST_INDEX, SECOND_INDEX);
+        List<Name> expectedNames = List.of(JOHN_NAME, HARRY_NAME);
+        // no whitespaces
+        assertParseSuccess(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING
+                        + SPACED_PREFIX_INDEX + SECOND_INDEX_STRING + SPACED_PREFIX_NAME + JOHN_STRING
+                        + SPACED_PREFIX_NAME + HARRY_STRING,
+                new AddToLessonCommand(FIRST_INDEX, expectedNames, expectedIndices));
+
+        // random whitespaces
+        assertParseSuccess(parser, "  \n \t" + FIRST_INDEX_STRING + " \n" + SPACED_PREFIX_INDEX
+                        + "  \t" + FIRST_INDEX_STRING
+                        + SPACED_PREFIX_INDEX + "    " + SECOND_INDEX_STRING + SPACED_PREFIX_NAME + JOHN_STRING
+                        + SPACED_PREFIX_NAME + HARRY_STRING,
+                new AddToLessonCommand(FIRST_INDEX, expectedNames, expectedIndices));
+    }
+
+    @Test
+    public void parse_missingNamesAndIndices_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToLessonCommand.MESSAGE_USAGE);
 
-        // missing student names
-        assertParseFailure(parser, "1", expectedMessage);
-
+        // missing student names without prefix
+        assertParseFailure(parser, " " + FIRST_INDEX_STRING + " ", expectedMessage);
         // missing index and student names
         assertParseFailure(parser, " ", expectedMessage);
+    }
+
+    @Test
+    public void parse_emptyIndex_failure() {
+        // missing student names with name prefix
+        assertParseFailure(parser, " " + FIRST_INDEX_STRING + SPACED_PREFIX_INDEX, MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_emptyName_failure() {
+        // missing student names with name prefix
+        assertParseFailure(parser, " " + FIRST_INDEX_STRING + SPACED_PREFIX_NAME, Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
@@ -46,18 +109,47 @@ public class AddToLessonCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToLessonCommand.MESSAGE_USAGE);
 
         // invalid index
-        assertParseFailure(parser, "-1 n/John Doe", expectedMessage);
+        assertParseFailure(parser, " " + INVALID_INDEX_NEGATIVE + SPACED_PREFIX_NAME + JOHN_STRING
+                + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING, expectedMessage);
 
         // non-numeric index
-        assertParseFailure(parser, "abc n/John Doe", expectedMessage);
+        assertParseFailure(parser, " " + INVALID_INDEX_LETTERS
+                + SPACED_PREFIX_INDEX + SECOND_INDEX_STRING, expectedMessage);
     }
 
     @Test
     public void parse_invalidName_failure() {
         // invalid name (empty name)
-        assertParseFailure(parser, "1 n/", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME, Name.MESSAGE_CONSTRAINTS);
 
-        // invalid name (numbers in name)
-        assertParseFailure(parser, "1 n/1234", Name.MESSAGE_CONSTRAINTS);
+        // invalid name (numbers in name) without any student indices
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME
+                + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid name (numbers in name) with student indices
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME
+                + INVALID_NAME_DESC + SPACED_PREFIX_INDEX + FIRST_INDEX_STRING, Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidStudentIndices_failure() {
+        // invalid name (empty name)
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX, MESSAGE_INVALID_INDEX);
+
+        // invalid student index (negative index) without any names
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX
+                + INVALID_INDEX_NEGATIVE, MESSAGE_INVALID_INDEX);
+
+        // invalid student index (letters in index) without any names
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_INDEX
+                + INVALID_INDEX_LETTERS, MESSAGE_INVALID_INDEX);
+
+        // invalid student index (negative index) with names
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME
+                + JOHN_STRING + SPACED_PREFIX_INDEX + INVALID_INDEX_NEGATIVE, MESSAGE_INVALID_INDEX);
+
+        // invalid student index (letters in index) with names
+        assertParseFailure(parser, FIRST_INDEX_STRING + SPACED_PREFIX_NAME
+                + JOHN_STRING + SPACED_PREFIX_INDEX + INVALID_INDEX_LETTERS, MESSAGE_INVALID_INDEX);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalLessons.java
+++ b/src/test/java/seedu/address/testutil/TypicalLessons.java
@@ -43,7 +43,6 @@ public class TypicalLessons {
     public static final Lesson LESSON_5 = new LessonBuilder()
             .withDate("2024-11-09")
             .withTime("16:00")
-            .withStudent(CARL)
             .build();
 
     private TypicalLessons() {} // prevents instantiation


### PR DESCRIPTION
Fixes #189 

Added support for passing indices when adding students to lessons.

Sample usage:
addtolesson 1 n/Harry Ng n/John Doe i/1 i/2

This command adds students at index 1 and 2 and Harry Ng and John Doe students to first index of the filtered lessons list

See #189 for more details