### PR TITLE
Improve Lesson List UI for Past Lessons

### DIFF
--- a/src/main/java/seedu/address/ui/LessonCard.java
+++ b/src/main/java/seedu/address/ui/LessonCard.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
@@ -59,6 +60,24 @@ public class LessonCard extends UiPart<Region> {
                     HBox studentBox = new HBox(0);
                     studentBox.getChildren().addAll(studentNameLabel, participationLabel);
                     students.getChildren().add(studentBox);
+
+                    // Combine date and time for comparison with current date and time
+                    LocalDateTime lessonDateTime = LocalDateTime.of(
+                            lesson.getDate().getLocalDateValue(),
+                            lesson.getTime().getLocalTimeValue());
+                    LocalDateTime currentDateTime = LocalDateTime.now();
+
+                    // Apply the appropriate CSS class based on the lesson time
+                    if (lessonDateTime.isBefore(currentDateTime)) {
+                        if (displayedIndex % 2 == 0) {
+                            cardPane.getStyleClass().add("lesson-card-past-even");
+                        } else {
+                            cardPane.getStyleClass().add("lesson-card-past-odd");
+                        }
+                        id.getStyleClass().add("lesson-card-strikethrough");
+                        date.getStyleClass().add("lesson-card-strikethrough");
+                        time.getStyleClass().add("lesson-card-strikethrough");
+                    }
                 });
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -409,15 +409,15 @@
     -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.5), 10, 0.5, 0, 4);
 }
 
-#cardPane.consultation-card-past-even {
+#cardPane.consultation-card-past-even, #cardPane.lesson-card-past-even {
     -fx-background-color: linear-gradient(from 0% 0% to 0% 100%, #B03434, #7D1515);
 }
 
-#cardPane.consultation-card-past-odd {
+#cardPane.consultation-card-past-odd, #cardPane.lesson-card-past-odd {
     -fx-background-color: linear-gradient(from 0% 0% to 0% 100%, #6B0808, #8D1C1C);
 }
 
-.consultation-card-strikethrough .text {
+.consultation-card-strikethrough .text, .lesson-card-strikethrough .text {
     -fx-strikethrough: true;
 }
 


### PR DESCRIPTION
Closes #208 

- Display Past Lessons as Red
- Strikethrough Timing of Past Lessons

### `Lessons` UI
![Screenshot 2024-10-30 211503](https://github.com/user-attachments/assets/72e7d2a9-86d0-48d8-8595-81f77655891a)
