### PR TITLE
Improve Layout of UI

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -24,6 +24,13 @@
     -fx-opacity: 1;
 }
 
+.label-list {
+    -fx-font-size: 16pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: white;
+    -fx-opacity: 1;
+}
+
 .text-field {
     -fx-font-size: 12pt;
     -fx-font-family: "Segoe UI Semibold";

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -25,10 +25,22 @@
 }
 
 .label-list {
-    -fx-font-size: 16pt;
+    -fx-font-size: 14pt;
     -fx-font-family: "Segoe UI Semibold";
-    -fx-text-fill: white;
+    -fx-text-fill: #F0F0F0;
+    -fx-letter-spacing: 1.5px;
     -fx-opacity: 1;
+    -fx-background-color: #4D4D4D;
+    -fx-background-radius: 10;
+    -fx-border-color: #888888;
+    -fx-border-width: 2px;
+    -fx-border-radius: 10;
+    -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.5), 10, 0, 0, 2);
+    -fx-alignment: center;
+}
+
+.label-list:hover {
+    -fx-background-color: #5a5a5a;
 }
 
 .text-field {
@@ -174,7 +186,6 @@
      -fx-border-top-width: 1px;
      -fx-border-width: 2;
      -fx-border-radius: 4;
-     -fx-padding: 10;
 }
 
 .status-bar {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root minHeight="600" minWidth="660" onCloseRequest="#handleExit" title="TAHub" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="720" onCloseRequest="#handleExit" title="TAHub" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -46,7 +46,7 @@
         <HBox VBox.vgrow="ALWAYS">
           <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
             <Tab text="Students">
-              <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="200" prefWidth="200" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+              <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                 <padding>
                   <Insets bottom="10" left="10" right="10" top="10" />
                 </padding>
@@ -56,7 +56,7 @@
           </TabPane>
           <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
             <Tab text="Consultations">
-              <VBox fx:id="consultationList" minWidth="200" prefWidth="200" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+              <VBox fx:id="consultationList" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                 <padding>
                   <Insets bottom="10" left="10" right="10" top="10" />
                 </padding>
@@ -66,7 +66,7 @@
           </TabPane>
           <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
             <Tab text="Lessons">
-              <VBox fx:id="lessonList" minWidth="200" prefWidth="200" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+              <VBox fx:id="lessonList" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                 <padding>
                   <Insets bottom="10" left="10" right="10" top="10" />
                 </padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="TAHub" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="660" onCloseRequest="#handleExit" title="TAHub" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -46,7 +46,7 @@
         <HBox VBox.vgrow="ALWAYS">
           <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
             <Tab text="Students">
-              <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="225" prefWidth="225" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+              <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="200" prefWidth="200" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                 <padding>
                   <Insets bottom="10" left="10" right="10" top="10" />
                 </padding>
@@ -54,24 +54,26 @@
               </VBox>
             </Tab>
           </TabPane>
-            <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-                <Tab text="Consultations">
-                  <VBox fx:id="consultationList" minWidth="225" prefWidth="225" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                    <padding>
-                      <Insets bottom="10" left="10" right="10" top="10" />
-                    </padding>
-                    <StackPane fx:id="consultationListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
-                  </VBox>
-                </Tab>
-              <Tab text="Lessons">
-                <VBox fx:id="lessonList" minWidth="225" prefWidth="225" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                  <padding>
-                    <Insets bottom="10" left="10" right="10" top="10" />
-                  </padding>
-                  <StackPane fx:id="lessonListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
-                </VBox>
-              </Tab>
-            </TabPane>
+          <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <Tab text="Consultations">
+              <VBox fx:id="consultationList" minWidth="200" prefWidth="200" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                <padding>
+                  <Insets bottom="10" left="10" right="10" top="10" />
+                </padding>
+                <StackPane fx:id="consultationListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
+              </VBox>
+            </Tab>
+          </TabPane>
+          <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <Tab text="Lessons">
+              <VBox fx:id="lessonList" minWidth="200" prefWidth="200" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                <padding>
+                  <Insets bottom="10" left="10" right="10" top="10" />
+                </padding>
+                <StackPane fx:id="lessonListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
+              </VBox>
+            </Tab>
+          </TabPane>
         </HBox>
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -44,36 +44,32 @@
         </VBox>
 
         <HBox VBox.vgrow="ALWAYS">
-          <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-            <Tab text="Students">
-              <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                <padding>
-                  <Insets bottom="10" left="10" right="10" top="10" />
-                </padding>
-                <StackPane fx:id="studentListPanelPlaceholder" prefHeight="540.0" prefWidth="318.0" VBox.vgrow="ALWAYS" />
-              </VBox>
-            </Tab>
-          </TabPane>
-          <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-            <Tab text="Consultations">
-              <VBox fx:id="consultationList" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                <padding>
-                  <Insets bottom="10" left="10" right="10" top="10" />
-                </padding>
-                <StackPane fx:id="consultationListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
-              </VBox>
-            </Tab>
-          </TabPane>
-          <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-            <Tab text="Lessons">
-              <VBox fx:id="lessonList" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                <padding>
-                  <Insets bottom="10" left="10" right="10" top="10" />
-                </padding>
-                <StackPane fx:id="lessonListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
-              </VBox>
-            </Tab>
-          </TabPane>
+          <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <Label text="Students" styleClass="label-list">
+              <padding>
+                <Insets bottom="10" left="10" right="10" top="10" />
+              </padding>
+            </Label>
+            <StackPane fx:id="studentListPanelPlaceholder" prefHeight="540.0" prefWidth="318.0" VBox.vgrow="ALWAYS" />
+          </VBox>
+
+          <VBox fx:id="consultationList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <Label text="Consultations" styleClass="label-list">
+              <padding>
+                <Insets bottom="10" left="10" right="10" top="10" />
+              </padding>
+            </Label>
+            <StackPane fx:id="consultationListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
+          </VBox>
+
+          <VBox fx:id="lessonList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <Label text="Lessons" styleClass="label-list">
+              <padding>
+                <Insets bottom="10" left="10" right="10" top="10" />
+              </padding>
+            </Label>
+            <StackPane fx:id="lessonListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
+          </VBox>
         </HBox>
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -29,8 +29,22 @@
           </Menu>
         </MenuBar>
 
+        <VBox maxHeight="Infinity" minWidth="200" prefWidth="100.0" HBox.hgrow="ALWAYS" VBox.vgrow="NEVER">
+          <StackPane fx:id="commandBoxPlaceholder" alignment="TOP_CENTER" prefHeight="101.0" prefWidth="341.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+            <padding>
+              <Insets bottom="5" left="10" right="10" top="5" />
+            </padding>
+          </StackPane>
+
+          <StackPane fx:id="resultDisplayPlaceholder" alignment="BOTTOM_CENTER" minHeight="100" prefHeight="250.0" prefWidth="341.0" styleClass="pane-with-border" VBox.vgrow="NEVER">
+            <padding>
+              <Insets bottom="5" left="10" right="10" top="5" />
+            </padding>
+          </StackPane>
+        </VBox>
+
         <HBox VBox.vgrow="ALWAYS">
-            <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS">
+            <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
               <Tab text="Students">
                   <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                     <padding>
@@ -56,20 +70,6 @@
                 </VBox>
               </Tab>
             </TabPane>
-
-          <VBox maxHeight="Infinity" minWidth="200" prefWidth="100.0" HBox.hgrow="ALWAYS" VBox.vgrow="NEVER">
-              <StackPane fx:id="commandBoxPlaceholder" alignment="TOP_CENTER" prefHeight="200" prefWidth="50.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                <padding>
-                  <Insets bottom="5" left="10" right="10" top="5" />
-                </padding>
-              </StackPane>
-
-            <StackPane fx:id="resultDisplayPlaceholder" alignment="BOTTOM_CENTER" minHeight="100" prefHeight="400" prefWidth="100.0" styleClass="pane-with-border" VBox.vgrow="NEVER">
-              <padding>
-                <Insets bottom="5" left="10" right="10" top="5" />
-              </padding>
-            </StackPane>
-          </VBox>
         </HBox>
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -44,17 +44,19 @@
         </VBox>
 
         <HBox VBox.vgrow="ALWAYS">
+          <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <Tab text="Students">
+              <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="225" prefWidth="225" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                <padding>
+                  <Insets bottom="10" left="10" right="10" top="10" />
+                </padding>
+                <StackPane fx:id="studentListPanelPlaceholder" prefHeight="540.0" prefWidth="318.0" VBox.vgrow="ALWAYS" />
+              </VBox>
+            </Tab>
+          </TabPane>
             <TabPane fx:id="tabList" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-              <Tab text="Students">
-                  <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                    <padding>
-                      <Insets bottom="10" left="10" right="10" top="10" />
-                    </padding>
-                    <StackPane fx:id="studentListPanelPlaceholder" prefHeight="540.0" prefWidth="318.0" VBox.vgrow="ALWAYS" />
-                  </VBox>
-                </Tab>
                 <Tab text="Consultations">
-                  <VBox fx:id="consultationList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                  <VBox fx:id="consultationList" minWidth="225" prefWidth="225" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                     <padding>
                       <Insets bottom="10" left="10" right="10" top="10" />
                     </padding>
@@ -62,7 +64,7 @@
                   </VBox>
                 </Tab>
               <Tab text="Lessons">
-                <VBox fx:id="lessonList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                <VBox fx:id="lessonList" minWidth="225" prefWidth="225" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                   <padding>
                     <Insets bottom="10" left="10" right="10" top="10" />
                   </padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -44,8 +44,8 @@
         </VBox>
 
         <HBox VBox.vgrow="ALWAYS">
-          <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-            <Label text="Students" styleClass="label-list">
+          <VBox fx:id="studentList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS">
+            <Label styleClass="label-list" text="Students">
               <padding>
                 <Insets bottom="10" left="10" right="10" top="10" />
               </padding>
@@ -53,8 +53,8 @@
             <StackPane fx:id="studentListPanelPlaceholder" prefHeight="540.0" prefWidth="318.0" VBox.vgrow="ALWAYS" />
           </VBox>
 
-          <VBox fx:id="consultationList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-            <Label text="Consultations" styleClass="label-list">
+          <VBox fx:id="consultationList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS">
+            <Label styleClass="label-list" text="Consultations">
               <padding>
                 <Insets bottom="10" left="10" right="10" top="10" />
               </padding>
@@ -62,8 +62,8 @@
             <StackPane fx:id="consultationListPanelPlaceholder" prefHeight="550.0" prefWidth="500.0" VBox.vgrow="ALWAYS" />
           </VBox>
 
-          <VBox fx:id="lessonList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-            <Label text="Lessons" styleClass="label-list">
+          <VBox fx:id="lessonList" alignment="TOP_CENTER" minWidth="240" prefWidth="240" styleClass="pane-with-border" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS">
+            <Label styleClass="label-list" text="Lessons">
               <padding>
                 <Insets bottom="10" left="10" right="10" top="10" />
               </padding>


### PR DESCRIPTION
Closes #186.

1. Shift Command Box & Results to Top
2. Display `Students`, `Consultations` & `Lessons` simultaneously
3. Replace Tabs with Labels

### Image of UI
![image](https://github.com/user-attachments/assets/210cef8a-0fa8-40b3-bfec-e573bc6350cf)