### PR TITLE
Change delete logic

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.consultation.exceptions.ConsultationNotFoundException;
@@ -165,10 +166,25 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     /**
      * Removes {@code key} from this {@code AddressBook}.
+     * Also removes the student from all consultations and lessons.
      * {@code key} must exist in the address book.
      */
     public void removeStudent(Student key) {
         students.remove(key);
+        // remove from consultations
+        FilteredList<Consultation> consultsWithDeletedStudent = consults.filtered(c -> c.hasStudent(key));
+        consultsWithDeletedStudent.forEach(c -> {
+            Consultation newConsult = new Consultation(c);
+            newConsult.removeStudent(key);
+            setConsult(c, newConsult);
+        });
+        // remove from lessons
+        FilteredList<Lesson> lessonsWithDeletedStudent = lessons.filtered(l -> l.hasStudent(key));
+        lessonsWithDeletedStudent.forEach(l -> {
+            Lesson newLesson = new Lesson(l);
+            newLesson.removeStudent(key);
+            setLesson(l, newLesson);
+        });
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.consultation.exceptions.ConsultationNotFoundException;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -171,15 +171,17 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeStudent(Student key) {
         students.remove(key);
+        // Note that we need to create a copy of the filtered list so that modifying consults within the forEach
+        // call does not cause an IndexOutOfBoundsException.
         // remove from consultations
-        FilteredList<Consultation> consultsWithDeletedStudent = consults.filtered(c -> c.hasStudent(key));
+        List<Consultation> consultsWithDeletedStudent = consults.filtered(c -> c.hasStudent(key)).stream().toList();
         consultsWithDeletedStudent.forEach(c -> {
             Consultation newConsult = new Consultation(c);
             newConsult.removeStudent(key);
             setConsult(c, newConsult);
         });
         // remove from lessons
-        FilteredList<Lesson> lessonsWithDeletedStudent = lessons.filtered(l -> l.hasStudent(key));
+        List<Lesson> lessonsWithDeletedStudent = lessons.filtered(l -> l.hasStudent(key)).stream().toList();
         lessonsWithDeletedStudent.forEach(l -> {
             Lesson newLesson = new Lesson(l);
             newLesson.removeStudent(key);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -64,6 +64,26 @@ public class AddressBookTest {
     }
 
     @Test
+    public void removeStudent_validStudent_alsoRemovedFromConsultsAndLessons() {
+        // setup
+        AddressBook addressBooks = new AddressBook();
+        addressBooks.addStudent(ALICE);
+        Consultation consultWithAlice = new ConsultationBuilder().withStudent(ALICE).build();
+        Lesson lessonWithAlice = new LessonBuilder().withStudent(ALICE).build();
+        addressBooks.addConsult(consultWithAlice);
+        addressBooks.addLesson(lessonWithAlice);
+        // remove ALICE
+        assert addressBooks.hasStudent(ALICE);
+        addressBooks.removeStudent(ALICE);
+        // check for no ALICE
+        Consultation resultConsult = addressBooks.getConsultList().get(0);
+        Lesson resultLesson = addressBooks.getLessonList().get(0);
+        assertFalse(addressBooks.hasStudent(ALICE));
+        assertFalse(resultConsult.hasStudent(ALICE));
+        assertFalse(resultLesson.hasStudent(ALICE));
+    }
+
+    @Test
     public void hasStudent_nullStudent_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> addressBook.hasStudent(null));
     }


### PR DESCRIPTION
Closes #188.

This PR:
- Changes the delete logic so that when a student is deleted, it is also removed from all consultations and lessons that contain the student.