### PR TITLE
Add set participation command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
@@ -1,0 +1,114 @@
+package seedu.address.logic.commands.lesson;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.lesson.Lesson;
+import seedu.address.model.student.Name;
+import seedu.address.model.student.Student;
+import seedu.address.model.student.exceptions.StudentNotFoundException;
+
+/**
+ * Marks chosen students' participation for a particular Lesson.
+ */
+public class MarkLessonParticipationCommand extends Command {
+
+    public static final String COMMAND_WORD = "markp";
+    public static final CommandType COMMAND_TYPE = CommandType.LESSON;
+
+    // TODO
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets the attendance of student(s) "
+            + "in a lesson at the chosen index in the lesson list to the specified value. "
+            + "\nParameters: LESSON_INDEX (must be a positive integer) "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_ATTENDANCE + "ATTENDANCE (1/y/Y or 0/n/N) "
+            + "\nExample: " + COMMAND_WORD + " 1 n/John Doe n/Jane Doe a/y";
+
+    public static final String MESSAGE_SUCCESS = "Marked the participation of %s as %s";
+    public static final String MESSAGE_STUDENT_NOT_FOUND_IN_ADDRESS_BOOK = "Student not found in TAHub: %s";
+    public static final String MESSAGE_STUDENT_NOT_FOUND_IN_LESSON = "Student not found in the lesson: %s";
+
+    private final Index index;
+    private final List<Name> studentNames;
+    private final int participationScore;
+    private final Logger logger = LogsCenter.getLogger(MarkLessonParticipationCommand.class);
+
+    /**
+     * @param index of the lesson in the filtered lesson list
+     * @param studentNames list of student names to target
+     * @param participationScore the student(s)' participation score
+     */
+    public MarkLessonParticipationCommand(Index index, List<Name> studentNames, int participationScore) {
+        requireAllNonNull(index, studentNames);
+        this.index = index;
+        this.studentNames = studentNames;
+        this.participationScore = participationScore;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        logger.info("Setting lesson participation of students");
+        List<Lesson> lastShownLessonList = model.getFilteredLessonList();
+
+        if (index.getZeroBased() >= lastShownLessonList.size()) {
+            throw new CommandException(String.format(MESSAGE_INVALID_LESSON_DISPLAYED_INDEX, index.getOneBased()));
+        }
+
+        Lesson targetLesson = lastShownLessonList.get(index.getZeroBased());
+        Lesson newLesson = new Lesson(targetLesson);
+
+        for (Name studentName : studentNames) {
+            Student student = model.findStudentByName(studentName)
+                    .orElseThrow(() -> new CommandException(
+                            String.format(MESSAGE_STUDENT_NOT_FOUND_IN_ADDRESS_BOOK, studentName)));
+            try {
+                newLesson.setParticipation(student, participationScore);
+            } catch (StudentNotFoundException e) {
+                throw new CommandException(String.format(MESSAGE_STUDENT_NOT_FOUND_IN_LESSON, studentName));
+            }
+        }
+
+        model.setLesson(targetLesson, newLesson);
+
+        logger.fine("Successfully marked participation of students in lesson " + targetLesson.toString());
+        String names = String.join(", ", studentNames.stream().map(x -> x.fullName).toList());
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, names, participationScore),
+                COMMAND_TYPE);
+    }
+
+    @Override
+    public CommandType getCommandType() {
+        return COMMAND_TYPE;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof MarkLessonParticipationCommand)) {
+            return false;
+        }
+
+        MarkLessonParticipationCommand otherCommand = (MarkLessonParticipationCommand) other;
+        return index.equals(otherCommand.index)
+                && studentNames.equals(otherCommand.studentNames)
+                && (participationScore == otherCommand.participationScore);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands.lesson;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POINTS;
 

--- a/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
@@ -42,8 +42,6 @@ public class MarkLessonParticipationCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Marked the participation of %s as %s";
     public static final String MESSAGE_STUDENT_NOT_FOUND_IN_ADDRESS_BOOK = "Student not found in TAHub: %s";
     public static final String MESSAGE_STUDENT_NOT_FOUND_IN_LESSON = "Student not found in the lesson: %s";
-    public static final String MESSAGE_INVALID_PARTICIPATION =
-            "Participation should be between 0-100 inclusive.";
 
     private final Index index;
     private final List<Name> studentNames;
@@ -62,6 +60,13 @@ public class MarkLessonParticipationCommand extends Command {
         this.participationScore = participationScore;
     }
 
+    /**
+     * Returns true if the participation score is valid, defined as being within the bounds.
+     */
+    public static boolean isValidParticipation(int score) {
+        return LOWER_BOUND <= score && score <= UPPER_BOUND;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -72,9 +77,8 @@ public class MarkLessonParticipationCommand extends Command {
             throw new CommandException(String.format(MESSAGE_INVALID_LESSON_DISPLAYED_INDEX, index.getOneBased()));
         }
 
-        if (!isWithinBounds(participationScore)) {
-            throw new CommandException(MESSAGE_INVALID_PARTICIPATION);
-        }
+        // this should have been checked in the parser
+        assert MarkLessonParticipationCommand.isValidParticipation(participationScore);
 
         Lesson targetLesson = lastShownLessonList.get(index.getZeroBased());
         Lesson newLesson = new Lesson(targetLesson);
@@ -100,13 +104,6 @@ public class MarkLessonParticipationCommand extends Command {
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, names, participationScore),
                 COMMAND_TYPE);
-    }
-
-    /**
-     * Returns true if the participation score is valid, defined as being within the bounds.
-     */
-    private boolean isWithinBounds(int score) {
-        return LOWER_BOUND <= score && score <= UPPER_BOUND;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_LESSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POINTS;
 
 import java.util.List;
 import java.util.logging.Logger;
@@ -28,18 +29,22 @@ public class MarkLessonParticipationCommand extends Command {
 
     public static final String COMMAND_WORD = "markp";
     public static final CommandType COMMAND_TYPE = CommandType.LESSON;
+    public static final int LOWER_BOUND = 0;
+    public static final int UPPER_BOUND = 100;
 
-    // TODO
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets the attendance of student(s) "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets the participation of student(s) "
             + "in a lesson at the chosen index in the lesson list to the specified value. "
+            + "\nIf their participation is set to a positive integer, also sets their attendance to true."
             + "\nParameters: LESSON_INDEX (must be a positive integer) "
             + PREFIX_NAME + "NAME "
-            + PREFIX_ATTENDANCE + "ATTENDANCE (1/y/Y or 0/n/N) "
-            + "\nExample: " + COMMAND_WORD + " 1 n/John Doe n/Jane Doe a/y";
+            + PREFIX_POINTS + "PARTICIPATION (integer from 0-100)"
+            + "\nExample: " + COMMAND_WORD + " 1 n/John Doe pt/1";
 
     public static final String MESSAGE_SUCCESS = "Marked the participation of %s as %s";
     public static final String MESSAGE_STUDENT_NOT_FOUND_IN_ADDRESS_BOOK = "Student not found in TAHub: %s";
     public static final String MESSAGE_STUDENT_NOT_FOUND_IN_LESSON = "Student not found in the lesson: %s";
+    public static final String MESSAGE_INVALID_PARTICIPATION =
+            "Participation should be between 0-100 inclusive.";
 
     private final Index index;
     private final List<Name> studentNames;
@@ -68,6 +73,10 @@ public class MarkLessonParticipationCommand extends Command {
             throw new CommandException(String.format(MESSAGE_INVALID_LESSON_DISPLAYED_INDEX, index.getOneBased()));
         }
 
+        if (!isWithinBounds(participationScore)) {
+            throw new CommandException(MESSAGE_INVALID_PARTICIPATION);
+        }
+
         Lesson targetLesson = lastShownLessonList.get(index.getZeroBased());
         Lesson newLesson = new Lesson(targetLesson);
 
@@ -77,6 +86,9 @@ public class MarkLessonParticipationCommand extends Command {
                             String.format(MESSAGE_STUDENT_NOT_FOUND_IN_ADDRESS_BOOK, studentName)));
             try {
                 newLesson.setParticipation(student, participationScore);
+                if (participationScore > 0) {
+                    newLesson.setAttendance(student, true);
+                }
             } catch (StudentNotFoundException e) {
                 throw new CommandException(String.format(MESSAGE_STUDENT_NOT_FOUND_IN_LESSON, studentName));
             }
@@ -89,6 +101,13 @@ public class MarkLessonParticipationCommand extends Command {
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, names, participationScore),
                 COMMAND_TYPE);
+    }
+
+    /**
+     * Returns true if the participation score is valid, defined as being within the bounds.
+     */
+    private boolean isWithinBounds(int score) {
+        return LOWER_BOUND <= score && score <= UPPER_BOUND;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.lesson.AddToLessonCommand;
 import seedu.address.logic.commands.lesson.DeleteLessonCommand;
 import seedu.address.logic.commands.lesson.ListLessonsCommand;
 import seedu.address.logic.commands.lesson.MarkLessonAttendanceCommand;
+import seedu.address.logic.commands.lesson.MarkLessonParticipationCommand;
 import seedu.address.logic.commands.lesson.RemoveFromLessonCommand;
 import seedu.address.logic.parser.consultation.AddConsultCommandParser;
 import seedu.address.logic.parser.consultation.AddToConsultCommandParser;
@@ -43,6 +44,7 @@ import seedu.address.logic.parser.lesson.AddLessonCommandParser;
 import seedu.address.logic.parser.lesson.AddToLessonCommandParser;
 import seedu.address.logic.parser.lesson.DeleteLessonCommandParser;
 import seedu.address.logic.parser.lesson.MarkLessonAttendanceCommandParser;
+import seedu.address.logic.parser.lesson.MarkLessonParticipationCommandParser;
 import seedu.address.logic.parser.lesson.RemoveFromLessonCommandParser;
 
 /**
@@ -148,6 +150,9 @@ public class AddressBookParser {
 
         case MarkLessonAttendanceCommand.COMMAND_WORD:
             return new MarkLessonAttendanceCommandParser().parse(arguments);
+
+        case MarkLessonParticipationCommand.COMMAND_WORD:
+            return new MarkLessonParticipationCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -24,6 +24,7 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_ATTENDANCE =
             "Invalid attendance entry. Please enter 1/Y/y for yes and 0/N/n for no.";
+    public static final String MESSAGE_INVALID_POINTS = "Points must be an integer between -2147483548 and 2147483647.";
 
     /**
      * Parses a {@code String date} into a {@code Date}.
@@ -167,5 +168,15 @@ public class ParserUtil {
         default ->
                 throw new ParseException(MESSAGE_INVALID_ATTENDANCE);
         };
+    }
+
+    public static int parsePoints(String points) throws ParseException {
+        requireNonNull(points);
+        String trimmedPoints = points.trim();
+        try {
+            return Integer.parseInt(trimmedPoints);
+        } catch (NumberFormatException e) {
+            throw new ParseException(MESSAGE_INVALID_POINTS);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -170,6 +170,12 @@ public class ParserUtil {
         };
     }
 
+    /**
+     * Parses a {@code points} into an integer. Points should be able to fit within a Java int primitive type.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given point value is invalid.
+     */
     public static int parsePoints(String points) throws ParseException {
         requireNonNull(points);
         String trimmedPoints = points.trim();

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.lesson.MarkLessonParticipationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.course.Course;
 import seedu.address.model.datetime.Date;
@@ -24,7 +25,8 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_ATTENDANCE =
             "Invalid attendance entry. Please enter 1/Y/y for yes and 0/N/n for no.";
-    public static final String MESSAGE_INVALID_POINTS = "Points must be an integer between -2147483548 and 2147483647.";
+    public static final String MESSAGE_INVALID_PARTICIPATION =
+            "Participation should be between 0-100 inclusive.";
 
     /**
      * Parses a {@code String date} into a {@code Date}.
@@ -179,10 +181,15 @@ public class ParserUtil {
     public static int parsePoints(String points) throws ParseException {
         requireNonNull(points);
         String trimmedPoints = points.trim();
+        int participationPoints = -1; // default invalid number
         try {
-            return Integer.parseInt(trimmedPoints);
+            participationPoints = Integer.parseInt(trimmedPoints);
         } catch (NumberFormatException e) {
-            throw new ParseException(MESSAGE_INVALID_POINTS);
+            throw new ParseException(MESSAGE_INVALID_PARTICIPATION);
         }
+        if (!MarkLessonParticipationCommand.isValidParticipation(participationPoints)) {
+            throw new ParseException(MESSAGE_INVALID_PARTICIPATION);
+        }
+        return participationPoints;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParser.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.parser.lesson;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POINTS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.lesson.MarkLessonAttendanceCommand;
+import seedu.address.logic.commands.lesson.MarkLessonParticipationCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.student.Name;
+
+/**
+ * Parses input arguments and creates a new MarkLessonAttendanceCommand object.
+ */
+public class MarkLessonParticipationCommandParser implements Parser<MarkLessonParticipationCommand> {
+
+    public static final String MESSAGE_TOO_MANY_PARTICIPATION_ARGUMENTS =
+            "Number of participation arguments must be exactly 1!";
+    private final Logger logger = LogsCenter.getLogger(MarkLessonParticipationCommandParser.class);
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkLessonAttendanceCommand
+     * and returns an MarkLessonAttendanceCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public MarkLessonParticipationCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_POINTS);
+
+        if (argMultimap.getPreamble().isEmpty() || !argMultimap.arePrefixesPresent(PREFIX_NAME, PREFIX_POINTS)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MarkLessonParticipationCommand.MESSAGE_USAGE));
+        }
+
+        // too many attendance arguments
+        if (argMultimap.getAllValues(PREFIX_POINTS).size() > 1) {
+            throw new ParseException(MESSAGE_TOO_MANY_PARTICIPATION_ARGUMENTS);
+        }
+
+        // Parse index
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+        // Parse names
+        List<Name> studentNames = new ArrayList<>();
+        for (String nameString : argMultimap.getAllValues(PREFIX_NAME)) {
+            try {
+                Name name = ParserUtil.parseName(nameString);
+                studentNames.add(name);
+            } catch (ParseException e) {
+                logger.warning("Name " + nameString + " could not be parsed properly");
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS, e);
+            }
+        }
+        // Parse participation
+        int participationScore = ParserUtil.parsePoints(argMultimap.getValue(PREFIX_POINTS).get());
+
+        return new MarkLessonParticipationCommand(index, studentNames, participationScore);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser.lesson;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDANCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POINTS;
 
@@ -12,7 +11,6 @@ import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.lesson.MarkLessonAttendanceCommand;
 import seedu.address.logic.commands.lesson.MarkLessonParticipationCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;

--- a/src/test/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommandTest.java
@@ -121,8 +121,8 @@ public class MarkLessonParticipationCommandTest {
         MarkLessonParticipationCommand command2 = new MarkLessonParticipationCommand(
                 VALID_INDEX, List.of(ALICE.getName()), 101);
 
-        assertThrows(CommandException.class, () -> command.execute(model));
-        assertThrows(CommandException.class, () -> command2.execute(model));
+        assertThrows(AssertionError.class, () -> command.execute(model));
+        assertThrows(AssertionError.class, () -> command2.execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommandTest.java
@@ -18,7 +18,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.lesson.Lesson;
 import seedu.address.model.student.Name;
 import seedu.address.testutil.LessonBuilder;
-import seedu.address.testutil.TypicalStudents;
 
 public class MarkLessonParticipationCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/lesson/MarkLessonParticipationCommandTest.java
@@ -1,0 +1,160 @@
+package seedu.address.logic.commands.lesson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalStudents.ALICE;
+import static seedu.address.testutil.TypicalStudents.BENSON;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelManager;
+import seedu.address.model.lesson.Lesson;
+import seedu.address.model.student.Name;
+import seedu.address.testutil.LessonBuilder;
+import seedu.address.testutil.TypicalStudents;
+
+public class MarkLessonParticipationCommandTest {
+
+    private static final Index VALID_INDEX = Index.fromOneBased(1);
+    private static final List<Name> VALID_NAMES = List.of(
+            ALICE.getName(), BENSON.getName());
+    private static final int VALID_PARTICIPATION = 1;
+    private static final Lesson LESSON = new LessonBuilder().withStudent(ALICE).build();
+
+    @Test
+    public void constructor_nullFields_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new MarkLessonParticipationCommand(null, VALID_NAMES, VALID_PARTICIPATION));
+        assertThrows(NullPointerException.class, () ->
+                new MarkLessonParticipationCommand(VALID_INDEX, null, VALID_PARTICIPATION));
+        assertThrows(NullPointerException.class, () ->
+                new MarkLessonParticipationCommand(null, null, VALID_PARTICIPATION));
+    }
+
+    @Test
+    public void execute_setParticipation_successful() throws Exception {
+        // The command uses a lot of methods from model, so making a stub is difficult
+        ModelManager model = new ModelManager();
+        // setup
+        model.addStudent(ALICE);
+        model.addLesson(LESSON);
+        Lesson expectedLesson = new Lesson(LESSON);
+        // should also set attendance of ALICE to true
+        expectedLesson.setAttendance(ALICE, true);
+        expectedLesson.setParticipation(ALICE, VALID_PARTICIPATION);
+
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(ALICE.getName()), VALID_PARTICIPATION);
+        CommandResult commandResult = command.execute(model);
+
+        assertEquals(String.format(
+                MarkLessonParticipationCommand.MESSAGE_SUCCESS, ALICE.getName(), VALID_PARTICIPATION),
+                commandResult.getFeedbackToUser());
+        assertTrue(model.hasLesson(expectedLesson));
+    }
+
+    @Test
+    public void execute_setParticipationToZero_successful() throws Exception {
+        ModelManager model = new ModelManager();
+        model.addStudent(ALICE);
+        model.addLesson(LESSON);
+        Lesson expectedLesson = new Lesson(LESSON);
+        expectedLesson.setParticipation(ALICE, 0); // note that attendance should remain false
+
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(ALICE.getName()), 0);
+        CommandResult commandResult = command.execute(model);
+
+        assertEquals(String.format(MarkLessonParticipationCommand.MESSAGE_SUCCESS, ALICE.getName(), 0),
+                commandResult.getFeedbackToUser());
+        assertTrue(model.hasLesson(expectedLesson));
+    }
+
+    @Test
+    public void execute_lessonIndexOutOfBounds_failure() {
+        ModelManager model = new ModelManager();
+        // setup
+        model.addLesson(LESSON);
+
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                Index.fromOneBased(100), List.of(ALICE.getName()), VALID_PARTICIPATION);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_studentNotInAddressBook_failure() {
+        ModelManager model = new ModelManager();
+        // setup
+        model.addLesson(LESSON);
+
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(ALICE.getName()), VALID_PARTICIPATION);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_studentNotInLesson_failure() {
+        ModelManager model = new ModelManager();
+        // setup
+        model.addStudent(BENSON);
+        model.addLesson(LESSON); // does not have BENSON
+
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(BENSON.getName()), VALID_PARTICIPATION);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_invalidParticipationScore_failure() {
+        ModelManager model = new ModelManager();
+        model.addStudent(ALICE);
+        model.addLesson(LESSON);
+
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                VALID_INDEX, List.of(ALICE.getName()), -1);
+        MarkLessonParticipationCommand command2 = new MarkLessonParticipationCommand(
+                VALID_INDEX, List.of(ALICE.getName()), 101);
+
+        assertThrows(CommandException.class, () -> command.execute(model));
+        assertThrows(CommandException.class, () -> command2.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        MarkLessonParticipationCommand command1 = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(ALICE.getName()), VALID_PARTICIPATION);
+        MarkLessonParticipationCommand command2 = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(ALICE.getName()), VALID_PARTICIPATION);
+        // different index
+        MarkLessonParticipationCommand command3 = new MarkLessonParticipationCommand(
+                Index.fromOneBased(2), List.of(ALICE.getName()), VALID_PARTICIPATION);
+        // different student
+        MarkLessonParticipationCommand command4 = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(BENSON.getName()), VALID_PARTICIPATION);
+        // different participation score
+        MarkLessonParticipationCommand command5 = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1), List.of(ALICE.getName()),
+                VALID_PARTICIPATION + 1);
+
+        assertTrue(command1.equals(command1));
+        assertTrue(command1.equals(command2));
+        assertFalse(command1.equals(command3));
+        assertFalse(command1.equals(command4));
+        assertFalse(command1.equals(command5));
+        assertFalse(command1.equals("hello codecov"));
+    }
+
+    @Test
+    public void getCommandType_returnsCorrectType() {
+        MarkLessonParticipationCommand command = new MarkLessonParticipationCommand(
+                VALID_INDEX, VALID_NAMES, VALID_PARTICIPATION);
+        assertEquals(MarkLessonParticipationCommand.COMMAND_TYPE, command.getCommandType());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -40,6 +40,7 @@ import seedu.address.logic.commands.lesson.AddLessonCommand;
 import seedu.address.logic.commands.lesson.DeleteLessonCommand;
 import seedu.address.logic.commands.lesson.ListLessonsCommand;
 import seedu.address.logic.commands.lesson.MarkLessonAttendanceCommand;
+import seedu.address.logic.commands.lesson.MarkLessonParticipationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.consultation.Consultation;
@@ -317,5 +318,16 @@ public class AddressBookParserTest {
         assertEquals(expectedCommand,
                 parser.parseCommand(MarkLessonAttendanceCommand.COMMAND_WORD
                         + " 1 n/Alice Pauline n/Benson Meier a/y"));
+    }
+
+    @Test
+    public void parseCommand_markLessonParticipation() throws Exception {
+        MarkLessonParticipationCommand expectedCommand = new MarkLessonParticipationCommand(
+                Index.fromOneBased(1),
+                List.of(TypicalStudents.ALICE.getName(), TypicalStudents.BENSON.getName()),
+                3);
+        assertEquals(expectedCommand,
+                parser.parseCommand(MarkLessonParticipationCommand.COMMAND_WORD
+                        + " 1 n/Alice Pauline n/Benson Meier pt/3"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
@@ -1,0 +1,78 @@
+package seedu.address.logic.parser.lesson;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_POINTS;
+import static seedu.address.logic.parser.lesson.MarkLessonParticipationCommandParser.MESSAGE_TOO_MANY_PARTICIPATION_ARGUMENTS;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.lesson.MarkLessonParticipationCommand;
+import seedu.address.model.student.Name;
+
+public class MarkLessonParticipationCommandParserTest {
+    private static final Index VALID_INDEX = Index.fromOneBased(1);
+    private static final List<Name> VALID_NAMES = List.of(new Name("Alice Tan"), new Name("Benson Son"));
+    private static final int VALID_PARTICIPATION = 1;
+    private final MarkLessonParticipationCommandParser parser = new MarkLessonParticipationCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        MarkLessonParticipationCommand expectedCommand = new MarkLessonParticipationCommand(
+                VALID_INDEX, VALID_NAMES, VALID_PARTICIPATION);
+        MarkLessonParticipationCommand expectedCommand2 = new MarkLessonParticipationCommand(
+                VALID_INDEX, VALID_NAMES, 0);
+        MarkLessonParticipationCommand expectedCommand3 = new MarkLessonParticipationCommand(
+                VALID_INDEX, VALID_NAMES, 100);
+
+        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/1", expectedCommand);
+        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/0", expectedCommand2);
+        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/100", expectedCommand3);
+    }
+
+    @Test
+    public void parse_missingFields_failure() {
+        String expectedMessage = String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, MarkLessonParticipationCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " ", expectedMessage);
+        assertParseFailure(parser, " n/Alice Tan n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidIndex_failure() {
+        String expectedMessage = MESSAGE_INVALID_INDEX;
+        assertParseFailure(parser, " 0 n/Alice Tan n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " -1 n/Alice Tan n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 2 n/Alice Tan n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " a n/Alice Tan n/Benson Son pt/1", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidName_failure() {
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        assertParseFailure(parser, " 1 n/Alic*@f n/Benson Son pt/1", expectedMessage);
+        // note that use of ; is not yet supported
+        assertParseFailure(parser, " 1 n/Alice Tan;Benson Son pt/1", expectedMessage);
+    }
+
+    @Test
+    public void parse_participationOutOfIntegerBounds_failure() {
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/7122647915963579", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/-712264795963579", MESSAGE_INVALID_POINTS);
+    }
+
+    @Test
+    public void parse_tooManyParticipationFields_failure() {
+        String expectedMessage = MESSAGE_TOO_MANY_PARTICIPATION_ARGUMENTS;
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/1 pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/1 pt/100", expectedMessage);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/79 pt/13", expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
@@ -31,6 +31,7 @@ public class MarkLessonParticipationCommandParserTest {
                 VALID_INDEX, VALID_NAMES, 100);
 
         assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/1", expectedCommand);
+        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/001", expectedCommand); // leading 0s ok
         assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/0", expectedCommand2);
         assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/100", expectedCommand3);
     }
@@ -60,6 +61,15 @@ public class MarkLessonParticipationCommandParserTest {
         assertParseFailure(parser, " 1 n/Alic*@f n/Benson Son pt/1", expectedMessage);
         // note that use of ; is not yet supported
         assertParseFailure(parser, " 1 n/Alice Tan;Benson Son pt/1", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidParticipation_failure() {
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/1.0", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/0.5", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/0.0", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/7122647915963579", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/-712264795963579", MESSAGE_INVALID_POINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
@@ -70,9 +70,12 @@ public class MarkLessonParticipationCommandParserTest {
 
     @Test
     public void parse_invalidParticipation_failure() {
-        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1.0", MESSAGE_INVALID_PARTICIPATION);
-        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/0.5", MESSAGE_INVALID_PARTICIPATION);
-        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/0.0", MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME
+                + " pt/1.0", MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME
+                + " pt/0.5", MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME
+                + " pt/0.0", MESSAGE_INVALID_PARTICIPATION);
         assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/7122647915963579",
                 MESSAGE_INVALID_PARTICIPATION);
         assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/-712264795963579",

--- a/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/lesson/MarkLessonParticipationCommandParserTest.java
@@ -4,8 +4,10 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_POINTS;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_PARTICIPATION;
 import static seedu.address.logic.parser.lesson.MarkLessonParticipationCommandParser.MESSAGE_TOO_MANY_PARTICIPATION_ARGUMENTS;
+import static seedu.address.testutil.TypicalStudents.ALICE;
+import static seedu.address.testutil.TypicalStudents.BENSON;
 
 import java.util.List;
 
@@ -17,7 +19,9 @@ import seedu.address.model.student.Name;
 
 public class MarkLessonParticipationCommandParserTest {
     private static final Index VALID_INDEX = Index.fromOneBased(1);
-    private static final List<Name> VALID_NAMES = List.of(new Name("Alice Tan"), new Name("Benson Son"));
+    private static final Name ALICE_NAME = ALICE.getName();
+    private static final Name BENSON_NAME = BENSON.getName();
+    private static final List<Name> VALID_NAMES = List.of(ALICE_NAME, BENSON_NAME);
     private static final int VALID_PARTICIPATION = 1;
     private final MarkLessonParticipationCommandParser parser = new MarkLessonParticipationCommandParser();
 
@@ -30,10 +34,11 @@ public class MarkLessonParticipationCommandParserTest {
         MarkLessonParticipationCommand expectedCommand3 = new MarkLessonParticipationCommand(
                 VALID_INDEX, VALID_NAMES, 100);
 
-        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/1", expectedCommand);
-        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/001", expectedCommand); // leading 0s ok
-        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/0", expectedCommand2);
-        assertParseSuccess(parser, " 1 n/Alice Tan n/Benson Son pt/100", expectedCommand3);
+        assertParseSuccess(parser, " 1 n/" + ALICE_NAME + " n/Benson Meier pt/1", expectedCommand);
+        // leading 0s should be ok
+        assertParseSuccess(parser, " 1 n/" + ALICE_NAME + " n/Benson Meier pt/001", expectedCommand);
+        assertParseSuccess(parser, " 1 n/" + ALICE_NAME + " n/Benson Meier pt/0", expectedCommand2);
+        assertParseSuccess(parser, " 1 n/Alice Pauline n/Benson Meier pt/100", expectedCommand3);
     }
 
     @Test
@@ -41,48 +46,52 @@ public class MarkLessonParticipationCommandParserTest {
         String expectedMessage = String.format(
                 MESSAGE_INVALID_COMMAND_FORMAT, MarkLessonParticipationCommand.MESSAGE_USAGE);
         assertParseFailure(parser, " ", expectedMessage);
-        assertParseFailure(parser, " n/Alice Tan n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " n/" + ALICE_NAME + " n/Benson Meier pt/1", expectedMessage);
         assertParseFailure(parser, " 1 pt/1", expectedMessage);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son", expectedMessage);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/Benson Meier", expectedMessage);
     }
 
     @Test
     public void parse_invalidIndex_failure() {
         String expectedMessage = MESSAGE_INVALID_INDEX;
-        assertParseFailure(parser, " 0 n/Alice Tan n/Benson Son pt/1", expectedMessage);
-        assertParseFailure(parser, " -1 n/Alice Tan n/Benson Son pt/1", expectedMessage);
-        assertParseFailure(parser, " 1 2 n/Alice Tan n/Benson Son pt/1", expectedMessage);
-        assertParseFailure(parser, " a n/Alice Tan n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " 0 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1", expectedMessage);
+        assertParseFailure(parser, " -1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 2 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1", expectedMessage);
+        assertParseFailure(parser, " a n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1", expectedMessage);
     }
 
     @Test
     public void parse_invalidName_failure() {
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
-        assertParseFailure(parser, " 1 n/Alic*@f n/Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 n/Alic*@f n/" + BENSON_NAME + " pt/1", expectedMessage);
         // note that use of ; is not yet supported
-        assertParseFailure(parser, " 1 n/Alice Tan;Benson Son pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + ";" + BENSON_NAME + " pt/1", expectedMessage);
     }
 
     @Test
     public void parse_invalidParticipation_failure() {
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/1.0", MESSAGE_INVALID_POINTS);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/0.5", MESSAGE_INVALID_POINTS);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/0.0", MESSAGE_INVALID_POINTS);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/7122647915963579", MESSAGE_INVALID_POINTS);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/-712264795963579", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1.0", MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/0.5", MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/0.0", MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/7122647915963579",
+                MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/-712264795963579",
+                MESSAGE_INVALID_PARTICIPATION);
     }
 
     @Test
     public void parse_participationOutOfIntegerBounds_failure() {
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/7122647915963579", MESSAGE_INVALID_POINTS);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/-712264795963579", MESSAGE_INVALID_POINTS);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/7122647915963579",
+                MESSAGE_INVALID_PARTICIPATION);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/-712264795963579",
+                MESSAGE_INVALID_PARTICIPATION);
     }
 
     @Test
     public void parse_tooManyParticipationFields_failure() {
         String expectedMessage = MESSAGE_TOO_MANY_PARTICIPATION_ARGUMENTS;
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/1 pt/1", expectedMessage);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/1 pt/100", expectedMessage);
-        assertParseFailure(parser, " 1 n/Alice Tan n/Benson Son pt/79 pt/13", expectedMessage);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1 pt/1", expectedMessage);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/1 pt/100", expectedMessage);
+        assertParseFailure(parser, " 1 n/" + ALICE_NAME + " n/" + BENSON_NAME + " pt/79 pt/13", expectedMessage);
     }
 }


### PR DESCRIPTION
Closes #174, closes #213.

This PR:
- Adds the `markp` command to mark students' participation for a specific lesson.
- Format: `markp <index> <n/name> <pt/participation>`. Example: `markp 1 n/John Doe pt/3`.
- Note: Participation only accepts integer values between 0 and 100 inclusive.