### PR TITLE
Fix UI with long text

### DIFF
--- a/src/main/java/seedu/address/ui/ConsultationCard.java
+++ b/src/main/java/seedu/address/ui/ConsultationCard.java
@@ -9,6 +9,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.consultation.Consultation;
+import seedu.address.model.student.Student;
 
 /**
  * A UI component that displays information of a {@code Consultation}.
@@ -59,6 +60,14 @@ public class ConsultationCard extends UiPart<Region> {
 
         consultation.getStudents().stream()
                 .sorted(Comparator.comparing(student -> student.getName().fullName))
-                .forEach(student -> students.getChildren().add(new Label(student.getName().fullName)));
+                .forEach(this::createLabel);
+    }
+
+    private void createLabel(Student student) {
+        Label label = new Label(student.getName().fullName);
+        label.maxWidthProperty().bind(students.widthProperty().add(-15));
+        label.setWrapText(true);
+        label.setMinWidth(students.getMinWidth());
+        students.getChildren().add(label);
     }
 }

--- a/src/main/java/seedu/address/ui/LessonCard.java
+++ b/src/main/java/seedu/address/ui/LessonCard.java
@@ -9,6 +9,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.lesson.Lesson;
+import seedu.address.model.student.Student;
 
 /**
  * A UI component that displays information of a {@code Lesson}.
@@ -59,26 +60,33 @@ public class LessonCard extends UiPart<Region> {
 
         lesson.getStudents().stream()
                 .sorted(Comparator.comparing(student -> student.getName().fullName))
-                .forEach(student -> {
-                    // Student Name
-                    Label studentNameLabel = new Label(student.getName().fullName);
-                    boolean hasAttendance = lesson.getAttendance(student);
+                .forEach(this::createLabel);
+    }
 
-                    // Student Attendance - Set Green (hasAttendance) or Red (NoAttendance)
-                    if (hasAttendance) {
-                        studentNameLabel.getStyleClass().add("lesson-card-has-attendance");
-                    } else {
-                        studentNameLabel.getStyleClass().add("lesson-card-no-attendance");
-                    }
+    private void createLabel(Student student) {
+        // Student Name
+        Label studentNameLabel = new Label(student.getName().fullName);
+        studentNameLabel.setWrapText(true);
+        studentNameLabel.maxWidthProperty().bind(students.widthProperty().add(-50));
+        studentNameLabel.setMinWidth(students.getMinWidth());
+        boolean hasAttendance = lesson.getAttendance(student);
 
-                    // Student Participation
-                    Label participationLabel = new Label(String.valueOf(lesson.getParticipation(student)));
-                    participationLabel.getStyleClass().add("participation-score");
+        // Student Attendance - Set Green (hasAttendance) or Red (NoAttendance)
+        if (hasAttendance) {
+            studentNameLabel.getStyleClass().add("lesson-card-has-attendance");
+        } else {
+            studentNameLabel.getStyleClass().add("lesson-card-no-attendance");
+        }
 
-                    // Combine All Details into Student Box
-                    HBox studentBox = new HBox(0);
-                    studentBox.getChildren().addAll(studentNameLabel, participationLabel);
-                    students.getChildren().add(studentBox);
-                });
+        // Student Participation
+        Label participationLabel = new Label(String.valueOf(lesson.getParticipation(student)));
+        participationLabel.getStyleClass().add("participation-score");
+
+        // Combine All Details into Student Box
+        HBox studentBox = new HBox(0);
+        studentBox.maxWidthProperty().bind(students.widthProperty().add(-20));
+        studentBox.getChildren().addAll(studentNameLabel, participationLabel);
+        studentBox.setMinWidth(students.getMinWidth());
+        students.getChildren().add(studentBox);
     }
 }

--- a/src/main/resources/view/ConsultationListCard.fxml
+++ b/src/main/resources/view/ConsultationListCard.fxml
@@ -28,7 +28,7 @@
                 <Label fx:id="date" text="\$date" styleClass="cell_big_label" />
                 <Label fx:id="time" text="\$time" styleClass="cell_big_label" />
             </HBox>
-            <FlowPane fx:id="students" styleClass="cell_big_label" />
+            <FlowPane fx:id="students" styleClass="cell_big_label" minWidth="10"/>
         </VBox>
     </GridPane>
 </HBox>

--- a/src/main/resources/view/LessonListCard.fxml
+++ b/src/main/resources/view/LessonListCard.fxml
@@ -28,7 +28,7 @@
                 <Label fx:id="date" text="\$date" styleClass="cell_big_label" />
                 <Label fx:id="time" text="\$time" styleClass="cell_big_label" />
             </HBox>
-            <FlowPane fx:id="students" styleClass="cell_big_label" />
+            <FlowPane fx:id="students" styleClass="cell_big_label" minWidth="10" />
         </VBox>
     </GridPane>
 </HBox>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -25,11 +25,11 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" />
       </HBox>
       <FlowPane fx:id="courses" styleClass="cell_big_label" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Closes #237.

This PR:
- Makes long names, phone numbers and emails wrap text in the student list. Note that courses are capped at a certain amount of characters already, so this is presumably not necessary.
- Makes long names wrap in the Consultations list, and also resize dynamically with the window size.
- Makes long names wrap in the Lessons list, and also resize dynamically with the window size.

![image](https://github.com/user-attachments/assets/1ec94043-a632-42aa-9068-4aa9a430b675)

Known Issues:
- There is a tendency for the consultation and lesson card heights to become extremely large. This fixes itself immediately once the user scrolls the list or clicks on the card. **I have no idea why this happens, nor how to fix it.**

![image](https://github.com/user-attachments/assets/6adffdc4-09e0-4b6d-8e56-6cfa6a1af2f7)