### PR TITLE
Add validation for filenames in Export

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "TAHub";
     font-size: 32px;
   }
 }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -177,7 +177,13 @@ public class ExportCommand extends Command {
         return escapedData;
     }
 
-    private void writeCsvFile(Path filePath, List<Student> studentList) throws IOException {
+    /**
+     * Writes all Students in a given List into a CSV file saved at filePath
+     * @param filePath Location to save CSV file
+     * @param studentList List of Students whose details should be saved
+     * @throws IOException Throws IO Exception
+     */
+    public void writeCsvFile(Path filePath, List<Student> studentList) throws IOException {
         assert filePath != null : "File path cannot be null";
         assert studentList != null : "Student list cannot be null";
         logger.fine("Writing CSV file to: " + filePath);
@@ -200,7 +206,12 @@ public class ExportCommand extends Command {
         }
     }
 
-    private String coursesToString(Set<Course> courses) {
+    /**
+     * Helper function that collects a set of Courses into a string for exporting
+     * @param courses Set of Courses to be collected into a string
+     * @return String representing a set of Courses
+     */
+    public String coursesToString(Set<Course> courses) {
         assert courses != null : "Courses set cannot be null";
         return courses.stream()
                 .map(Course::toString)

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -25,7 +25,6 @@ public class ExportCommand extends Command {
     public static final String COMMAND_WORD = "export";
     public static final String FORCE_FLAG = "-f";
     public static final CommandType COMMAND_TYPE = CommandType.STUDENT;
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports the current list of students to a CSV file. "
             + "Parameters: FILENAME " + "[" + FORCE_FLAG + "] "
             + "\nExample: " + COMMAND_WORD + " students"
@@ -37,6 +36,9 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_HOME_FILE_EXISTS =
             "File %1$s already exists in home directory. Use -f flag to overwrite.";
     public static final String MESSAGE_SUCCESS_WITH_COPY = "Exported %1$d students to %2$s and %3$s";
+    public static final String INVALID_CHARS = "*/\\";
+    public static final String INVALID_FILENAME_MESSAGE =
+            "Filename cannot contain '%s'. Only alphanumeric characters, spaces, and basic punctuation are allowed.";
     private static final Logger logger = LogsCenter.getLogger(ExportCommand.class);
 
     private final String filename;
@@ -79,9 +81,29 @@ public class ExportCommand extends Command {
         return Paths.get(System.getProperty("user.home"), filename + ".csv");
     }
 
+    /**
+     * Validates if filename is valid
+     *
+     * @param filename String representing filename to be validated
+     */
+    private void validateFilename(String filename) throws CommandException {
+        // Check for invalid characters
+        for (char c : INVALID_CHARS.toCharArray()) {
+            if (filename.indexOf(c) >= 0) {
+                throw new CommandException(String.format(INVALID_FILENAME_MESSAGE, c));
+            }
+        }
+
+        // Additional validation to ensure it's just a filename
+        if (Paths.get(filename).getNameCount() > 1) {
+            throw new CommandException("Filename cannot contain path components");
+        }
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         assert model != null : "Model cannot be null";
+        validateFilename(filename);
         List<Student> studentList = model.getFilteredStudentList();
         logger.info("Starting export for " + studentList.size() + " students");
 

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,7 +37,7 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_HOME_FILE_EXISTS =
             "File %1$s already exists in home directory. Use -f flag to overwrite.";
     public static final String MESSAGE_SUCCESS_WITH_COPY = "Exported %1$d students to %2$s and %3$s";
-    public static final String INVALID_CHARS = "*/\\";
+    public static final String INVALID_CHARS = "*/\\" + File.separator;
     public static final String INVALID_FILENAME_MESSAGE =
             "Filename cannot contain '%s'. Only alphanumeric characters, spaces, and basic punctuation are allowed.";
     private static final Logger logger = LogsCenter.getLogger(ExportCommand.class);
@@ -87,16 +88,10 @@ public class ExportCommand extends Command {
      * @param filename String representing filename to be validated
      */
     private void validateFilename(String filename) throws CommandException {
-        // Check for invalid characters
         for (char c : INVALID_CHARS.toCharArray()) {
             if (filename.indexOf(c) >= 0) {
                 throw new CommandException(String.format(INVALID_FILENAME_MESSAGE, c));
             }
-        }
-
-        // Additional validation to ensure it's just a filename
-        if (Paths.get(filename).getNameCount() > 1) {
-            throw new CommandException("Filename cannot contain path components");
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -37,9 +36,8 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_HOME_FILE_EXISTS =
             "File %1$s already exists in home directory. Use -f flag to overwrite.";
     public static final String MESSAGE_SUCCESS_WITH_COPY = "Exported %1$d students to %2$s and %3$s";
-    public static final String INVALID_CHARS = "*/\\" + File.separator;
     public static final String INVALID_FILENAME_MESSAGE =
-            "Filename cannot contain '%s'. Only alphanumeric characters, spaces, and basic punctuation are allowed.";
+            "Filename can only contain alphanumeric characters (A-Z, a-z, 0-9)";
     private static final Logger logger = LogsCenter.getLogger(ExportCommand.class);
 
     private final String filename;
@@ -87,11 +85,9 @@ public class ExportCommand extends Command {
      *
      * @param filename String representing filename to be validated
      */
-    private void validateFilename(String filename) throws CommandException {
-        for (char c : INVALID_CHARS.toCharArray()) {
-            if (filename.indexOf(c) >= 0) {
-                throw new CommandException(String.format(INVALID_FILENAME_MESSAGE, c));
-            }
+    protected void validateFilename(String filename) throws CommandException {
+        if (!filename.matches("^[a-zA-Z0-9]+$")) {
+            throw new CommandException(INVALID_FILENAME_MESSAGE);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/consultation/ExportConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/ExportConsultCommand.java
@@ -33,12 +33,15 @@ public class ExportConsultCommand extends Command {
             + "\nExample: " + COMMAND_WORD + " consultations"
             + "\nExample with force flag: " + COMMAND_WORD + " " + FORCE_FLAG + " consultations";
 
-    public static final String MESSAGE_SUCCESS = "Exported %1$d consultations to %2$s";
     public static final String MESSAGE_FAILURE = "Failed to export consultations: %1$s";
     public static final String MESSAGE_FILE_EXISTS = "File %1$s already exists. Use -f flag to overwrite.";
     public static final String MESSAGE_HOME_FILE_EXISTS =
             "File %1$s already exists in home directory. Use -f flag to overwrite.";
+    public static final String MESSAGE_SUCCESS = "Exported %1$d consultations to %2$s";
     public static final String MESSAGE_SUCCESS_WITH_COPY = "Exported %1$d consultations to %2$s and %3$s";
+    public static final String INVALID_CHARS = "*/\\";
+    public static final String INVALID_FILENAME_MESSAGE =
+            "Filename cannot contain '%s'. Only alphanumeric characters, spaces, and basic punctuation are allowed.";
 
     private static final Logger logger = LogsCenter.getLogger(ExportConsultCommand.class);
 
@@ -68,8 +71,28 @@ public class ExportConsultCommand extends Command {
         return Paths.get(System.getProperty("user.home"), filename + ".csv");
     }
 
+    /**
+     * Validates if filename is valid
+     *
+     * @param filename String representing filename to be validated
+     */
+    private void validateFilename(String filename) throws CommandException {
+        // Check for invalid characters
+        for (char c : INVALID_CHARS.toCharArray()) {
+            if (filename.indexOf(c) >= 0) {
+                throw new CommandException(String.format(INVALID_FILENAME_MESSAGE, c));
+            }
+        }
+
+        // Additional validation to ensure it's just a filename
+        if (Paths.get(filename).getNameCount() > 1) {
+            throw new CommandException("Filename cannot contain path components");
+        }
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        validateFilename(filename);
         List<Consultation> consultList = model.getFilteredConsultationList();
         logger.info("Starting export for " + consultList.size() + " consultations");
 

--- a/src/main/java/seedu/address/logic/commands/consultation/ExportConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/ExportConsultCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands.consultation;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -39,7 +40,7 @@ public class ExportConsultCommand extends Command {
             "File %1$s already exists in home directory. Use -f flag to overwrite.";
     public static final String MESSAGE_SUCCESS = "Exported %1$d consultations to %2$s";
     public static final String MESSAGE_SUCCESS_WITH_COPY = "Exported %1$d consultations to %2$s and %3$s";
-    public static final String INVALID_CHARS = "*/\\";
+    public static final String INVALID_CHARS = "*/\\" + File.separator;
     public static final String INVALID_FILENAME_MESSAGE =
             "Filename cannot contain '%s'. Only alphanumeric characters, spaces, and basic punctuation are allowed.";
 
@@ -77,16 +78,10 @@ public class ExportConsultCommand extends Command {
      * @param filename String representing filename to be validated
      */
     private void validateFilename(String filename) throws CommandException {
-        // Check for invalid characters
         for (char c : INVALID_CHARS.toCharArray()) {
             if (filename.indexOf(c) >= 0) {
                 throw new CommandException(String.format(INVALID_FILENAME_MESSAGE, c));
             }
-        }
-
-        // Additional validation to ensure it's just a filename
-        if (Paths.get(filename).getNameCount() > 1) {
-            throw new CommandException("Filename cannot contain path components");
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/consultation/ExportConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/ExportConsultCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands.consultation;
 
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,9 +39,8 @@ public class ExportConsultCommand extends Command {
             "File %1$s already exists in home directory. Use -f flag to overwrite.";
     public static final String MESSAGE_SUCCESS = "Exported %1$d consultations to %2$s";
     public static final String MESSAGE_SUCCESS_WITH_COPY = "Exported %1$d consultations to %2$s and %3$s";
-    public static final String INVALID_CHARS = "*/\\" + File.separator;
     public static final String INVALID_FILENAME_MESSAGE =
-            "Filename cannot contain '%s'. Only alphanumeric characters, spaces, and basic punctuation are allowed.";
+            "Filename can only contain alphanumeric characters (A-Z, a-z, 0-9)";
 
     private static final Logger logger = LogsCenter.getLogger(ExportConsultCommand.class);
 
@@ -77,11 +75,10 @@ public class ExportConsultCommand extends Command {
      *
      * @param filename String representing filename to be validated
      */
-    private void validateFilename(String filename) throws CommandException {
-        for (char c : INVALID_CHARS.toCharArray()) {
-            if (filename.indexOf(c) >= 0) {
-                throw new CommandException(String.format(INVALID_FILENAME_MESSAGE, c));
-            }
+    protected void validateFilename(String filename) throws CommandException {
+        // Check if filename contains any non-alphanumeric characters
+        if (!filename.matches("^[a-zA-Z0-9]+$")) {
+            throw new CommandException(ExportConsultCommand.INVALID_FILENAME_MESSAGE);
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.commands.ExportCommand.MESSAGE_HOME_FILE_EXIST
 import static seedu.address.logic.commands.ExportCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -675,26 +673,5 @@ public class ExportCommandTest {
 
         assertThrows(AssertionError.class, () ->
                 exportCommand.coursesToString(null));
-    }
-
-    @Test
-    public void validateFilename_withPathComponents_throwsCommandException() {
-        String filenameWithPath = "folder" + File.separator + "file";
-        ExportCommand exportCommand = new ExportCommand(filenameWithPath, false, dataDir);
-        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
-                "Filename cannot contain path components");
-    }
-
-    @Test
-    public void validateFilename_multiplePathComponents_throwsCommandException() {
-        String filenameWithPath = "parent/child/file";
-        ExportCommand exportCommand = new ExportCommand(filenameWithPath, false, dataDir);
-
-        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
-                "Filename cannot contain path components");
-        String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
-        ExportCommand exportCommand2 = new ExportCommand(explicitPath, false, dataDir);
-        Assertions.assertThrows(CommandException.class, () -> exportCommand2.execute(model),
-                "Filename cannot contain path components");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -645,6 +645,35 @@ public class ExportCommandTest {
                 String.format(ExportCommand.INVALID_FILENAME_MESSAGE, '\\'), () -> exportCommand.execute(model));
     }
 
+    @Test
+    public void writeCsvFile_nullPath_throwsAssertionError() throws IOException {
+        Student sampleStudent = createSampleStudent();
+        model.addStudent(sampleStudent);
+        ExportCommand exportCommand = new ExportCommand("test", false, dataDir);
+
+        assertThrows(AssertionError.class, () ->
+                exportCommand.writeCsvFile(null, model.getFilteredStudentList()));
+    }
+
+    @Test
+    public void writeCsvFile_nullStudentList_throwsAssertionError() throws IOException {
+        ExportCommand exportCommand = new ExportCommand("test", false, dataDir);
+        Path dataFile = dataDir.resolve("test.csv");
+
+        assertThrows(AssertionError.class, () ->
+                exportCommand.writeCsvFile(dataFile, null));
+    }
+
+    @Test
+    public void coursesToString_nullCourses_throwsAssertionError() {
+        Student sampleStudent = createSampleStudent();
+        model.addStudent(sampleStudent);
+        ExportCommand exportCommand = new ExportCommand("test", false, dataDir);
+
+        assertThrows(AssertionError.class, () ->
+                exportCommand.coursesToString(null));
+    }
+
     /**
      * Helper method to throw a fail
      * @param message Error message to pass to AssertionError

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -684,6 +684,14 @@ public class ExportCommandTest {
                 "Filename cannot contain path components");
     }
 
+    @Test
+    public void validateFilename_multiplePathComponents_throwsCommandException() {
+        String filenameWithPath = "parent" + File.separator + "file";
+        ExportCommand exportCommand = new ExportCommand(filenameWithPath, false, dataDir);
+        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                "Filename cannot contain path components");
+    }
+
     /**
      * Helper method to throw a fail
      * @param message Error message to pass to AssertionError

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.address.logic.commands.ExportCommand.MESSAGE_FAILURE;
 import static seedu.address.logic.commands.ExportCommand.MESSAGE_FILE_EXISTS;
 import static seedu.address.logic.commands.ExportCommand.MESSAGE_HOME_FILE_EXISTS;
@@ -686,17 +687,14 @@ public class ExportCommandTest {
 
     @Test
     public void validateFilename_multiplePathComponents_throwsCommandException() {
-        String filenameWithPath = "parent" + File.separator + "file";
+        String filenameWithPath = "parent/child/file";
         ExportCommand exportCommand = new ExportCommand(filenameWithPath, false, dataDir);
+
         Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
-    }
-
-    /**
-     * Helper method to throw a fail
-     * @param message Error message to pass to AssertionError
-     */
-    private void fail(String message) {
-        throw new AssertionError(message);
+        String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
+        ExportCommand exportCommand2 = new ExportCommand(explicitPath, false, dataDir);
+        Assertions.assertThrows(CommandException.class, () -> exportCommand2.execute(model),
+                "Filename cannot contain path components");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.ExportCommand.MESSAGE_HOME_FILE_EXIST
 import static seedu.address.logic.commands.ExportCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -672,6 +674,14 @@ public class ExportCommandTest {
 
         assertThrows(AssertionError.class, () ->
                 exportCommand.coursesToString(null));
+    }
+
+    @Test
+    public void validateFilename_withPathComponents_throwsCommandException() {
+        String filenameWithPath = "folder" + File.separator + "file";
+        ExportCommand exportCommand = new ExportCommand(filenameWithPath, false, dataDir);
+        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                "Filename cannot contain path components");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -624,6 +624,27 @@ public class ExportCommandTest {
         assertTrue(lines.get(1).contains(sampleStudent.getName().fullName));
     }
 
+    @Test
+    public void execute_filenameWithWildcard_throwsCommandException() throws IOException {
+        ExportCommand exportCommand = new ExportCommand("test*", false, dataDir);
+        assertThrows(CommandException.class,
+                String.format(ExportCommand.INVALID_FILENAME_MESSAGE, '*'), () -> exportCommand.execute(model));
+    }
+
+    @Test
+    public void execute_filenameWithForwardSlash_throwsCommandException() throws IOException {
+        ExportCommand exportCommand = new ExportCommand("test/file", false, dataDir);
+        assertThrows(CommandException.class,
+                String.format(ExportCommand.INVALID_FILENAME_MESSAGE, '/'), () -> exportCommand.execute(model));
+    }
+
+    @Test
+    public void execute_filenameWithBackslash_throwsCommandException() throws IOException {
+        ExportCommand exportCommand = new ExportCommand("test\\file", false, dataDir);
+        assertThrows(CommandException.class,
+                String.format(ExportCommand.INVALID_FILENAME_MESSAGE, '\\'), () -> exportCommand.execute(model));
+    }
+
     /**
      * Helper method to throw a fail
      * @param message Error message to pass to AssertionError

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -674,4 +674,24 @@ public class ExportCommandTest {
         assertThrows(AssertionError.class, () ->
                 exportCommand.coursesToString(null));
     }
+
+    @Test
+    public void execute_filenameWithSpecialCharacters_throwsCommandException() {
+        String[] invalidFilenames = {
+            "test-file",
+            "test_file",
+            "test file",
+            "test!file",
+            "test@file",
+            "test#file",
+            "test$file",
+            "test.file"
+        };
+
+        for (String filename : invalidFilenames) {
+            ExportCommand exportCommand = new ExportCommand(filename, false, dataDir);
+            assertThrows(CommandException.class,
+                    ExportCommand.INVALID_FILENAME_MESSAGE, () -> exportCommand.execute(model));
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalConsultations.getTypicalConsultations;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,7 +15,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -357,25 +355,5 @@ public class ExportConsultCommandTest {
 
         // Test with multiple special characters
         assertEquals("\"test,\"\"'data\"", exportCommand.escapeSpecialCharacters("test,\"'data"));
-    }
-
-    @Test
-    public void validateFilename_withPathComponents_throwsCommandException() {
-        String filenameWithPath = "folder" + File.separator + "file";
-        ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
-        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
-                "Filename cannot contain path components");
-    }
-
-    @Test
-    public void validateFilename_multiplePathComponents_throwsCommandException() {
-        String filenameWithPath = "parent/child/file";
-        ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
-        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
-                "Filename cannot contain path components");
-        String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
-        ExportConsultCommand exportCommand2 = new ExportConsultCommand(explicitPath, false, dataDir);
-        Assertions.assertThrows(CommandException.class, () -> exportCommand2.execute(model),
-                "Filename cannot contain path components");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -362,7 +363,7 @@ public class ExportConsultCommandTest {
     public void validateFilename_withPathComponents_throwsCommandException() {
         String filenameWithPath = "folder" + File.separator + "file";
         ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
-        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
     }
 
@@ -372,14 +373,14 @@ public class ExportConsultCommandTest {
         String filenameWithPath = "parent.child.file";
         ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
 
-        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
 
         // Also test with explicit path separator
         String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
         ExportConsultCommand exportCommand2 = new ExportConsultCommand(explicitPath, false, dataDir);
 
-        assertThrows(CommandException.class, () -> exportCommand2.execute(model),
+        Assertions.assertThrows(CommandException.class, () -> exportCommand2.execute(model),
                 "Filename cannot contain path components");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalConsultations.getTypicalConsultations;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -355,5 +356,13 @@ public class ExportConsultCommandTest {
 
         // Test with multiple special characters
         assertEquals("\"test,\"\"'data\"", exportCommand.escapeSpecialCharacters("test,\"'data"));
+    }
+
+    @Test
+    public void validateFilename_withPathComponents_throwsCommandException() {
+        String filenameWithPath = "folder" + File.separator + "file";
+        ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
+        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                "Filename cannot contain path components");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -366,4 +366,16 @@ public class ExportConsultCommandTest {
         Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
     }
+
+    @Test
+    public void validateFilename_multiplePathComponents_throwsCommandException() {
+        String filenameWithPath = "parent/child/file";
+        ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
+        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                "Filename cannot contain path components");
+        String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
+        ExportConsultCommand exportCommand2 = new ExportConsultCommand(explicitPath, false, dataDir);
+        Assertions.assertThrows(CommandException.class, () -> exportCommand2.execute(model),
+                "Filename cannot contain path components");
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -366,21 +366,4 @@ public class ExportConsultCommandTest {
         Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
     }
-
-    @Test
-    public void validateFilename_multiplePathComponents_throwsCommandException() {
-        // Create a filename with multiple path components using periods
-        String filenameWithPath = "parent.child.file";
-        ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
-
-        assertThrows(CommandException.class, () -> exportCommand.execute(model),
-                "Filename cannot contain path components");
-
-        // Also test with explicit path separator
-        String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
-        ExportConsultCommand exportCommand2 = new ExportConsultCommand(explicitPath, false, dataDir);
-
-        assertThrows(CommandException.class, () -> exportCommand2.execute(model),
-                "Filename cannot contain path components");
-    }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -365,4 +365,21 @@ public class ExportConsultCommandTest {
         assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
     }
+
+    @Test
+    public void validateFilename_multiplePathComponents_throwsCommandException() {
+        // Create a filename with multiple path components using periods
+        String filenameWithPath = "parent.child.file";
+        ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
+
+        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                "Filename cannot contain path components");
+
+        // Also test with explicit path separator
+        String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
+        ExportConsultCommand exportCommand2 = new ExportConsultCommand(explicitPath, false, dataDir);
+
+        assertThrows(CommandException.class, () -> exportCommand2.execute(model),
+                "Filename cannot contain path components");
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -373,14 +373,14 @@ public class ExportConsultCommandTest {
         String filenameWithPath = "parent.child.file";
         ExportConsultCommand exportCommand = new ExportConsultCommand(filenameWithPath, false, dataDir);
 
-        Assertions.assertThrows(CommandException.class, () -> exportCommand.execute(model),
+        assertThrows(CommandException.class, () -> exportCommand.execute(model),
                 "Filename cannot contain path components");
 
         // Also test with explicit path separator
         String explicitPath = "parent" + File.separator + "child" + File.separator + "file";
         ExportConsultCommand exportCommand2 = new ExportConsultCommand(explicitPath, false, dataDir);
 
-        Assertions.assertThrows(CommandException.class, () -> exportCommand2.execute(model),
+        assertThrows(CommandException.class, () -> exportCommand2.execute(model),
                 "Filename cannot contain path components");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -23,6 +23,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.testutil.ModelStub;
@@ -244,6 +245,27 @@ public class ExportConsultCommandTest {
         Path anotherExpected = Paths.get(System.getProperty("user.home"), anotherFilename + ".csv");
         Path anotherActual = exportCommand.getHomeFilePath(anotherFilename);
         assertEquals(anotherExpected, anotherActual);
+    }
+
+    @Test
+    public void execute_filenameWithWildcard_throwsCommandException() throws IOException {
+        ExportConsultCommand exportCommand = new ExportConsultCommand("test*", false, dataDir);
+        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                String.format(ExportConsultCommand.INVALID_FILENAME_MESSAGE, '*'));
+    }
+
+    @Test
+    public void execute_filenameWithForwardSlash_throwsCommandException() throws IOException {
+        ExportConsultCommand exportCommand = new ExportConsultCommand("test/file", false, dataDir);
+        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                String.format(ExportConsultCommand.INVALID_FILENAME_MESSAGE, '/'));
+    }
+
+    @Test
+    public void execute_filenameWithBackslash_throwsCommandException() throws IOException {
+        ExportConsultCommand exportCommand = new ExportConsultCommand("test\\file", false, dataDir);
+        assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                String.format(ExportCommand.INVALID_FILENAME_MESSAGE, '\\'));
     }
 
     private class ModelStubWithConsultations extends ModelStub {

--- a/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/ExportConsultCommandTest.java
@@ -23,7 +23,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
-import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.testutil.ModelStub;
@@ -265,7 +264,7 @@ public class ExportConsultCommandTest {
     public void execute_filenameWithBackslash_throwsCommandException() throws IOException {
         ExportConsultCommand exportCommand = new ExportConsultCommand("test\\file", false, dataDir);
         assertThrows(CommandException.class, () -> exportCommand.execute(model),
-                String.format(ExportCommand.INVALID_FILENAME_MESSAGE, '\\'));
+                String.format(ExportConsultCommand.INVALID_FILENAME_MESSAGE, '\\'));
     }
 
     private class ModelStubWithConsultations extends ModelStub {
@@ -355,5 +354,25 @@ public class ExportConsultCommandTest {
 
         // Test with multiple special characters
         assertEquals("\"test,\"\"'data\"", exportCommand.escapeSpecialCharacters("test,\"'data"));
+    }
+
+    @Test
+    public void execute_filenameWithSpecialCharacters_throwsCommandException() {
+        String[] invalidFilenames = {
+            "test-file",
+            "test_file",
+            "test file",
+            "test!file",
+            "test@file",
+            "test#file",
+            "test$file",
+            "test.file"
+        };
+
+        for (String filename : invalidFilenames) {
+            ExportConsultCommand exportCommand = new ExportConsultCommand(filename, false, dataDir);
+            assertThrows(CommandException.class, () -> exportCommand.execute(model),
+                    ExportConsultCommand.INVALID_FILENAME_MESSAGE);
+        }
     }
 }


### PR DESCRIPTION
Fixes #271 #281 #302

Bug testers reported that special characters commonly used in file systems like *, / and \ were causing issues or inconsistencies. This commit adds a validation check for filenames and prevents these special characters from being used, enforcing only alphanumeric filenames.

This is a functionality issue as the possibility of special characters being used in filenames could potentially cause unforeseen bugs.