### PR TITLE
Bugfix for add to consult command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
@@ -5,11 +5,14 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_CONSULTATION_DISPLAYE
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
@@ -20,7 +23,6 @@ import seedu.address.model.Model;
 import seedu.address.model.consultation.Consultation;
 import seedu.address.model.student.Name;
 import seedu.address.model.student.Student;
-import seedu.address.model.student.exceptions.DuplicateStudentException;
 
 /**
  * Adds students to a specific consultation.
@@ -43,6 +45,7 @@ public class AddToConsultCommand extends Command {
             "%s is already added to the consultation!";
     public static final String MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX =
             "%s at index %d is already added to the consultation!";
+    private final Logger logger = LogsCenter.getLogger(AddToConsultCommand.class);
 
 
 
@@ -80,16 +83,27 @@ public class AddToConsultCommand extends Command {
         Consultation targetConsultation = lastShownList.get(index.getZeroBased());
         Consultation editedConsultation = new Consultation(targetConsultation);
 
+        Set<Student> studentsToAddSet = new HashSet<>();
+        ArrayList<Student> studentsToAddArr = new ArrayList<>();
+
         for (Name studentName : studentNames) {
             Student student = model.findStudentByName(studentName)
                     .orElseThrow(() -> new CommandException(
                             String.format(MESSAGE_STUDENT_NOT_FOUND, studentName)));
-            try {
-                editedConsultation.addStudent(student);
-            } catch (DuplicateStudentException e) {
+
+            // if student was already in the lesson before this command, throw error
+            if (editedConsultation.hasStudent(student)) {
+                logger.warning("Students were not added to consult " + targetConsultation.toString()
+                    + " because the student " + studentName + " was already in consult");
                 throw new CommandException(
                         String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME, studentName));
             }
+
+            //if student was not previously in the lesson before this command, add it to the set
+            if (!studentsToAddSet.contains(student)) {
+                studentsToAddArr.add(student);
+            }
+            studentsToAddSet.add(student);
         }
 
         // check if any of the indices are out of bounds of the filtered student list
@@ -104,25 +118,38 @@ public class AddToConsultCommand extends Command {
         }
 
         if (throwException) {
+
             String formattedOutOfBoundIndices = outOfBounds.stream()
                     .map(index -> String.valueOf(index.getOneBased()))
                     .collect(Collectors.joining(", "));
+            logger.warning("Students were not added to consult " + targetConsultation.toString()
+                    + " because indices " + formattedOutOfBoundIndices + " were out of bounds");
             throw new CommandException(String.format(Messages.MESSAGE_INVALID_INDEX_SHOWN, formattedOutOfBoundIndices));
         }
 
         // Make sure that there are no duplicate students. Since logic handling duplicate students is done here for
         // adding students by name, logic for handling duplicate indices are also handled here
-        for (Index studentIndices : indices) {
-            Student student = lastShownStudentList.get(studentIndices.getZeroBased());
-            try {
-                editedConsultation.addStudent(student);
-            } catch (DuplicateStudentException e) {
+        for (Index studentIndex : indices) {
+            Student student = lastShownStudentList.get(studentIndex.getZeroBased());
+
+            if (editedConsultation.hasStudent(student)) {
+                logger.warning("Students were not added to lesson " + targetConsultation.toString()
+                    + " because student " + student.getName() + " was already in the consult");
                 throw new CommandException(
                         String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX, student.getName(),
-                                studentIndices.getOneBased()));
+                                studentIndex.getOneBased()));
             }
+
+            if (!studentsToAddSet.contains(student)) {
+                studentsToAddArr.add(student);
+            }
+            studentsToAddSet.add(student);
         }
 
+        // actually adding the students into the lesson
+        for (Student student: studentsToAddArr) {
+            editedConsultation.addStudent(student);
+        }
         model.setConsult(targetConsultation, editedConsultation);
 
         return new CommandResult(

--- a/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/consultation/AddToConsultCommandTest.java
@@ -51,6 +51,9 @@ public class AddToConsultCommandTest {
             new Name(CARL.getName().fullName), new Name(CARL.getName().fullName));
     private final ObservableList<Index> validStudentIndices = FXCollections.observableArrayList(
             INDEX_FIRST_STUDENT, INDEX_SECOND_STUDENT); //contains Alice and Bob
+
+    private final ObservableList<Index> duplicateIndices = FXCollections.observableArrayList(
+            INDEX_FIRST_STUDENT, INDEX_FIRST_STUDENT);
     private ObservableList<Index> invalidIndices;
 
     @BeforeEach
@@ -166,16 +169,58 @@ public class AddToConsultCommandTest {
     }
 
     @Test
-    public void execute_duplicateStudentByIndex_throwsCommandException() {
-        ObservableList<Index> duplicateIndices = FXCollections.observableArrayList(
-                INDEX_FIRST_STUDENT, INDEX_FIRST_STUDENT);
+    public void execute_duplicateStudentByIndexSuccess() throws Exception {
+
         AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
                 validStudentNames, duplicateIndices);
 
-        String error = String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_INDEX, ALICE.getName().fullName,
-                INDEX_FIRST_STUDENT.getOneBased());
 
-        assertCommandFailure(command, model, error);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        CommandResult result = command.execute(model);
+
+        Consultation targetConsultation = expectedModel.getFilteredConsultationList()
+                .get(validConsultIndex5.getZeroBased());
+        Consultation editedConsultation = new Consultation(targetConsultation);
+
+        editedConsultation.addStudent(CARL);
+        editedConsultation.addStudent(DANIEL);
+        editedConsultation.addStudent(ALICE);
+        expectedModel.setConsult(targetConsultation, editedConsultation);
+
+        String expectedMessage = String.format(MESSAGE_ADD_TO_CONSULT_SUCCESS, Messages.format(editedConsultation));
+
+        assertEquals(result.getFeedbackToUser(), expectedMessage);
+        assertEquals(expectedModel.getFilteredConsultationList().get(validConsultIndex5.getZeroBased()),
+                model.getFilteredConsultationList().get(validConsultIndex5.getZeroBased()));
+
+    }
+
+    public void execute_duplicateStudentByNameSuccess() throws Exception {
+
+        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
+                duplicateStudentNames, validStudentIndices);
+
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        CommandResult result = command.execute(model);
+
+        Consultation targetConsultation = expectedModel.getFilteredConsultationList()
+                .get(validConsultIndex5.getZeroBased());
+        Consultation editedConsultation = new Consultation(targetConsultation);
+
+        editedConsultation.addStudent(CARL);
+        editedConsultation.addStudent(ALICE);
+        editedConsultation.addStudent(BENSON);
+        expectedModel.setConsult(targetConsultation, editedConsultation);
+
+        String expectedMessage = String.format(MESSAGE_ADD_TO_CONSULT_SUCCESS, Messages.format(editedConsultation));
+
+        assertEquals(result.getFeedbackToUser(), expectedMessage);
+        assertEquals(expectedModel.getFilteredConsultationList().get(validConsultIndex5.getZeroBased()),
+                model.getFilteredConsultationList().get(validConsultIndex5.getZeroBased()));
+
     }
 
     @Test
@@ -204,16 +249,6 @@ public class AddToConsultCommandTest {
                 MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME, ALICE.getName());
 
         assertCommandFailure(command, model, duplicateStudentInConsultError);
-    }
-
-    @Test
-    public void execute_duplicateStudentByName_throwsCommandException() {
-        AddToConsultCommand command = new AddToConsultCommand(validConsultIndex5,
-                duplicateStudentNames, validStudentIndices);
-
-        String error = String.format(MESSAGE_DUPLICATE_STUDENT_IN_CONSULTATION_BY_NAME, CARL.getName().fullName);
-
-        assertCommandFailure(command, model, error);
     }
 
     @Test


### PR DESCRIPTION
Fixes #268 , partially addresses #299

Previously, when multiple of the same students are added in the same command, an exception is thrown. 

Now, when that happens, the student is added successfully.