### PR TITLE
PLEASE CHECK THIS Update error message example to show index

### DIFF
--- a/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/AddToConsultCommand.java
@@ -34,7 +34,7 @@ public class AddToConsultCommand extends Command {
             + "by the index number used in the displayed consultation list. "
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME]… [" + PREFIX_INDEX + "INDEX]…\n"
-            + "Example: " + COMMAND_WORD + " 1 n/John Doe n/Harry Ng";
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NAME + "John Doe " + PREFIX_INDEX + "1";
 
     public static final String MESSAGE_ADD_TO_CONSULT_SUCCESS = "Added students to the Consultation: %1$s";
 


### PR DESCRIPTION
Fixes #298 

Issue says that the error message does not adequately display usage of indices in addtoconsult command. Since the behaviour is already mentioned in DG/UG, I think its ok to edit the error message to show this. 